### PR TITLE
Fix README link on scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Internally when you call **gsudo**, it launches itself elevated as a background 
 
 ## Instalation
 
-[Scoop](https://chocolatey.org/install) users: 
+[Scoop](https://scoop.sh) users: 
 
 ``` batch
 scoop install gsudo


### PR DESCRIPTION
Was most likely an oversight of copy-pasting but the Scoop link actually redirects to the Chocolatey homepage.