### PR TITLE
Release v0.7.2 

### DIFF
--- a/build/Build.bat
+++ b/build/Build.bat
@@ -30,8 +30,9 @@ if errorlevel 1 echo Sign Failed & pause & goto badend
 
 del Releases\gsudo.v%version%.zip
 :skipbuild
+Set PSModulePath=
 7z a Releases\gsudo.v%version%.zip ..\src\gsudo\bin\ilmerge\*.*
-powershell (Get-FileHash Releases\gsudo.v%version%.zip).hash > Releases\gsudo.v%version%.zip.sha256
+powershell -Command ECHO (Get-FileHash Releases\gsudo.v%version%.zip).hash > Releases\gsudo.v%version%.zip.sha256
 
 :: Chocolatey
 git clean Chocolatey\gsudo\Bin -xf

--- a/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
@@ -23,6 +23,15 @@ if (Test-Path "$bin\sudo.exe")
   Remove-Item "$bin\sudo.exe"
 }
 
+# Remove from User Path on previous versions ( <= 0.7.1 )
+$toolsPath = Split-Path -parent $MyInvocation.MyCommand.Definition
+$unScriptPath = Join-Path $toolsPath "Uninstall-ChocolateyPath.psm1"
+$installPath = "$env:ChocolateyInstall\lib\gsudo\bin\"
+Import-Module $unScriptPath
+
+Uninstall-ChocolateyPath $installPath 'User' | Out-Null
+
+# Add to System Path
 Install-ChocolateyPath -PathToInstall $bin -PathType 'Machine'
 
 cmd /c mklink "$bin\sudo.exe" "$bin\gsudo.exe"

--- a/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
@@ -23,7 +23,7 @@ if (Test-Path "$bin\sudo.exe")
   Remove-Item "$bin\sudo.exe"
 }
 
-Install-ChocolateyPath -PathToInstall $bin -PathType 'User'
+Install-ChocolateyPath -PathToInstall $bin -PathType 'Machine'
 
 cmd /c mklink "$bin\sudo.exe" "$bin\gsudo.exe"
 

--- a/build/Chocolatey/gsudo/tools/chocolateyuninstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyuninstall.ps1
@@ -4,4 +4,4 @@ $unScriptPath = Join-Path $toolsPath "Uninstall-ChocolateyPath.psm1"
 $installPath = "$env:ChocolateyInstall\lib\gsudo\bin\"
 
 Import-Module $unScriptPath
-Uninstall-ChocolateyPath $installPath 'Machine'
+Uninstall-ChocolateyPath $installPath 'Machine' | Out-Null

--- a/build/Chocolatey/gsudo/tools/chocolateyuninstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyuninstall.ps1
@@ -4,4 +4,4 @@ $unScriptPath = Join-Path $toolsPath "Uninstall-ChocolateyPath.psm1"
 $installPath = "$env:ChocolateyInstall\lib\gsudo\bin\"
 
 Import-Module $unScriptPath
-Uninstall-ChocolateyPath $installPath 'User'
+Uninstall-ChocolateyPath $installPath 'Machine'

--- a/src/gsudo/Commands/BangBangCommand.cs
+++ b/src/gsudo/Commands/BangBangCommand.cs
@@ -1,11 +1,8 @@
 ﻿using gsudo.Helpers;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace gsudo.Commands
@@ -42,7 +39,7 @@ namespace gsudo.Commands
             }
             else if (Pattern.StartsWith("!?", StringComparison.OrdinalIgnoreCase))
             {
-                commandToElevate = commandHistory.FirstOrDefault(s => s.Contains(Pattern.Substring(2).Trim()));
+                commandToElevate = commandHistory.FirstOrDefault(s => s.ToUpperInvariant().Contains(Pattern.Substring(2).Trim().ToUpperInvariant()));
             }
             else // Pattern.StartsWith ("!command")
             {

--- a/src/gsudo/Helpers/ConsoleHelper.cs
+++ b/src/gsudo/Helpers/ConsoleHelper.cs
@@ -30,7 +30,9 @@ namespace gsudo.Helpers
             return true;
         }
 
-        internal static bool IgnoreConsoleCancelKeyPress(CtrlTypes ctrlType)
+        internal static SetConsoleCtrlEventHandler IgnoreConsoleCancelKeyPress;
+
+        private static bool IgnoreConsoleCancelKeyPressMethod(CtrlTypes ctrlType)
         {
             if (ctrlType.In(CtrlTypes.CTRL_C_EVENT, CtrlTypes.CTRL_BREAK_EVENT))
                 return true;
@@ -38,6 +40,9 @@ namespace gsudo.Helpers
             return false;
         }
 
-
+        static ConsoleHelper()
+        {
+            IgnoreConsoleCancelKeyPress += IgnoreConsoleCancelKeyPressMethod;
+        }
     }
 }

--- a/src/gsudo/Native/ConsoleApi.cs
+++ b/src/gsudo/Native/ConsoleApi.cs
@@ -37,8 +37,9 @@ namespace gsudo.Native
             CTRL_SHUTDOWN_EVENT
         }
 
+        internal delegate bool SetConsoleCtrlEventHandler(CtrlTypes sig);
         [DllImport("kernel32.dll", SetLastError = true)]
-        internal static extern bool SetConsoleCtrlHandler(ConsoleEventDelegate callback, bool add);
+        internal static extern bool SetConsoleCtrlHandler(SetConsoleCtrlEventHandler callback, bool add);
 
         [DllImport("kernel32.dll")]
         public static extern uint GetLastError();

--- a/src/gsudo/Settings.cs
+++ b/src/gsudo/Settings.cs
@@ -22,7 +22,7 @@ namespace gsudo
             = new RegistrySetting<string>(nameof(PipedPrompt), "$P# ", (s) => s);
 
         public static RegistrySetting<string> Prompt { get; set; }
-            = new RegistrySetting<string>(nameof(Prompt), "$p$e[1;31;40m# $e[0;37;40m", (s) => s);
+            = new RegistrySetting<string>(nameof(Prompt), "$p$e[1;31;40m# $e[0m", (s) => s);
 
         public static RegistrySetting<LogLevel> LogLevel { get; set; }
             = new RegistrySetting<LogLevel>(nameof(LogLevel), gsudo.LogLevel.Info,

--- a/src/gsudo/gsudo.csproj
+++ b/src/gsudo/gsudo.csproj
@@ -13,7 +13,7 @@ It is a sudo equivalent for Windows, with a similar user-experience as the origi
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <Version>0.5</Version>
+    <Version>0.7.2</Version>
     <Copyright>2019 Gerardo Grignoli</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/gerardog/gsudo</PackageProjectUrl>


### PR DESCRIPTION
Fixes:

- Fix Unhandled Exception when pressing CTRL+C after 4 minutes runtime  (Ctrl-C Handler delegate was garbage collected). (#53)
- Fix Choco package issue when the user is not admin and installs as another user (#50)
- Fix gsudo red ´#´ prompt breaking console color scheme on some scenarios (#51)
- Fix `gsudo !prefix` now case insensitive.