### PR TITLE
Allow Choco Upgrade with gsudo running (draft) #74

### DIFF
--- a/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
@@ -3,16 +3,27 @@
   return [bool]($file.Attributes -band [IO.FileAttributes]::ReparsePoint)
 }
 
-if (Get-Process gsudo -ErrorAction SilentlyContinue) {
-	gsudo.exe -k
-	Start-Sleep -Milliseconds 500
+if (Test-Path "$bin\gsudo.exe.previous") {
+  Remove-Item "$bin\gsudo.exe.previous" | Out-Null
+}
+
+if (Test-Path "$bin\gsudo.exe") {
 	if (Get-Process gsudo -ErrorAction SilentlyContinue) {
-		$ErrorActionPreference = "Stop"
-		Write-Output '##### Please close gsudo before installing.             #####'
-		Write-Output '##### Or run in new window with "-n" to let gsudo exit: #####'
-		Write-Output '        gsudo -n cmd /k choco upgrade gsudo'
-		
-		throw "Unable to install/uninstall if gsudo is running"
+		gsudo.exe -k
+		Start-Sleep -Milliseconds 500
+			
+		if (Get-Process gsudo -ErrorAction SilentlyContinue) {
+			Rename-Item "$bin\gsudo.exe" "$bin\gsudo.exe.previous"
+
+			if(! ($?)) {
+				$ErrorActionPreference = "Stop"
+				Write-Output '##### Please close gsudo before installing.             #####'
+				Write-Output '##### Or run in new window with "-n" to let gsudo exit: #####'
+				Write-Output '        gsudo -n cmd /k choco upgrade gsudo'
+				
+				throw "Unable to install/uninstall if gsudo is running"
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
* gsudo.exe is in use, so we can't overwrite it
* Windows allows to rename gsudo.exe to gsudo.exe.previous if '.previous` does not exists.
* `gsudo.exe.previous` can be deleted beforehand if the file is not in use. If it is, we are out of luck.

To Test:
* test fresh install, and upgrade from 0.7.2, and an older one like 0.6
* test what-if sudo.exe alias is in use
* test what-if `gsudo.exe.previous` is in use 
* test uninstall with `gsudo.exe.previous` file present
