### PR TITLE
Support Take Command (regardless of COMSPEC)

### DIFF
--- a/src/gsudo/Helpers/ArgumentsHelper.cs
+++ b/src/gsudo/Helpers/ArgumentsHelper.cs
@@ -123,6 +123,14 @@ namespace gsudo.Helpers
                     else
                         return args;
                 }
+                else if (currentShell == Shell.TakeCommand)
+                {
+                    if (args.Length == 0)
+                        return new[] { currentShellExeName, "/k" };
+                    else
+                        return new[] { currentShellExeName, "/c" }
+                            .Concat(args).ToArray();
+                }
             }
 
             if (currentShell != Shell.Cmd)

--- a/src/gsudo/Helpers/ShellHelper.cs
+++ b/src/gsudo/Helpers/ShellHelper.cs
@@ -13,6 +13,7 @@ namespace gsudo.Helpers
         Yori,
         Wsl,
         Bash,
+        TakeCommand
     }
 
     static class ShellHelper
@@ -45,6 +46,10 @@ namespace gsudo.Helpers
                 else if (parentExeName == "BASH.EXE")
                 {
                     return Shell.Bash;
+                }
+                else if (parentExeName == "TCC.EXE")
+                {
+                    return Shell.TakeCommand;
                 }
                 else if (parentExeName == "CMD.EXE")
                 {


### PR DESCRIPTION
Take command usually sets COMSPEC, but often (as in my case)
COMSPEC still points to cmd.exe for obscure batch file compatibility.