### PR TITLE
Feature: Force NewWindow + New window --NoClose & Shell --NoExit

### DIFF
--- a/src/gsudo.Tests/CommandLineParserTests.cs
+++ b/src/gsudo.Tests/CommandLineParserTests.cs
@@ -16,7 +16,7 @@ namespace gsudo.Tests
             {
                 var runCmd = result as RunCommand;
                 Assert.IsNotNull(runCmd);
-                Assert.AreEqual("cmd /c echo 1 2 3 4", string.Join(" ", runCmd.CommandToRun));
+                Assert.AreEqual("\"C:\\Windows\\system32\\cmd.EXE\" /c echo 1 2 3 4", string.Join(" ", runCmd.UserCommand));
 
                 Assert.IsTrue(InputArguments.NewWindow);
                 Assert.IsTrue(InputArguments.Wait);
@@ -44,7 +44,7 @@ namespace gsudo.Tests
 
             var runCmd = ret as RunCommand;
             Assert.IsNotNull(runCmd);
-            Assert.AreEqual("cmd /c echo 1 2 3 4", string.Join(" ", runCmd.CommandToRun));
+            Assert.AreEqual("\"C:\\Windows\\system32\\cmd.EXE\" /c echo 1 2 3 4", string.Join(" ", runCmd.UserCommand));
 
             Assert.IsTrue(InputArguments.NewWindow);
             Assert.IsFalse(InputArguments.Wait);
@@ -65,7 +65,7 @@ namespace gsudo.Tests
 
             var runCmd = ret as RunCommand;
             Assert.IsNotNull(runCmd);
-            Assert.AreEqual("", string.Join(" ", runCmd.CommandToRun));
+            Assert.AreEqual("", string.Join(" ", runCmd.UserCommand));
 
             Assert.IsFalse(InputArguments.NewWindow);
             Assert.IsFalse(InputArguments.Wait);
@@ -84,7 +84,7 @@ namespace gsudo.Tests
             {
                 var runCmd = result as RunCommand;
                 Assert.IsNotNull(runCmd);
-                CollectionAssert.AreEqual(new string[] { "notepad", "\"1 2 3 4\"" }, runCmd.CommandToRun.ToArray());
+                CollectionAssert.AreEqual(new string[] { "\"C:\\windows\\system32\\notepad.exe\"", "\"1 2 3 4\"" }, runCmd.UserCommand.ToArray(), StringComparer.OrdinalIgnoreCase);
 
                 Assert.IsTrue(InputArguments.NewWindow);
                 Assert.IsTrue(InputArguments.Wait);

--- a/src/gsudo/AppSettings/RegistrySetting.cs
+++ b/src/gsudo/AppSettings/RegistrySetting.cs
@@ -3,7 +3,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 
-namespace gsudo
+namespace gsudo.AppSettings
 {
     public enum RegistrySettingScope { 
         /// <summary>
@@ -45,7 +45,7 @@ namespace gsudo
 
         public RegistrySetting(string name, Func<T> defaultValue, Func<string, T> deserializer, RegistrySettingScope scope = RegistrySettingScope.Any, Func<T,string> serializer = null)
         {
-            Name = name;
+            Name = name.Replace('_', '.');
             this.defaultValue = defaultValue;
             this.deserializer = deserializer;
             this.Scope = scope;

--- a/src/gsudo/AppSettings/Settings.cs
+++ b/src/gsudo/AppSettings/Settings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using gsudo.AppSettings;
 using gsudo.CredentialsCache;
 using Microsoft.Win32;
 
@@ -30,7 +31,8 @@ namespace gsudo
         public static RegistrySetting<string> PipedPrompt { get; }
             = new RegistrySetting<string>(nameof(PipedPrompt), 
                 defaultValue: DefaultAsciiPrompt, 
-                deserializer: (s) => s);
+                deserializer: (s) => s
+                );
 
         public static RegistrySetting<string> Prompt { get; }
             = new RegistrySetting<string>(nameof(Prompt),
@@ -84,13 +86,28 @@ namespace gsudo
                 deserializer: (string s)=>s,
                 scope: RegistrySettingScope.GlobalOnly);
 
+        public static RegistrySetting<bool> NewWindow_Force { get; } =
+            new RegistrySetting<bool>(nameof(NewWindow_Force),
+                defaultValue: false,
+                deserializer: bool.Parse,
+                scope: RegistrySettingScope.Any);
+
+        public static RegistrySetting<CloseBehaviour> NewWindow_CloseBehaviour { get; } =
+            new RegistrySetting<CloseBehaviour>(nameof(NewWindow_CloseBehaviour),
+                defaultValue: CloseBehaviour.OsDefault,
+                deserializer: ExtensionMethods.ParseEnum<CloseBehaviour>,
+                scope: RegistrySettingScope.Any);
+
         public static IDictionary<string, RegistrySetting> AllKeys =>
             new Dictionary<string, RegistrySetting>(StringComparer.OrdinalIgnoreCase)
                 .Add(
                     CacheMode,
                     CacheDuration,
                     LogLevel,
-                    
+
+                    NewWindow_Force,
+                    NewWindow_CloseBehaviour,
+
                     Prompt,
                     PipedPrompt,
 

--- a/src/gsudo/AppSettings/Window.cs
+++ b/src/gsudo/AppSettings/Window.cs
@@ -1,0 +1,16 @@
+﻿namespace gsudo.AppSettings
+{
+    // CacheMode = Disabled | Explicit | Auto
+    // Cache.Mode = Disabled | Manual | AutoStart | AutoStart
+    // Cache.Restriction = CallerPIDOnly | CallerPIDAndDescendants | AnySameUserPid
+
+    // NewWindow.Force = true
+    // NewWindow.CloseBehaviour = KeepShellOpen | PressKeyToClose | OsDefault
+
+    public enum CloseBehaviour
+    {
+        KeepShellOpen,
+        PressKeyToClose,
+        OsDefault,
+    }
+}

--- a/src/gsudo/Commands/ConfigCommand.cs
+++ b/src/gsudo/Commands/ConfigCommand.cs
@@ -1,4 +1,5 @@
-﻿using gsudo.Helpers;
+﻿using gsudo.AppSettings;
+using gsudo.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +20,14 @@ namespace gsudo.Commands
             if (key.In("-h", "/h", "/?", "-?", "--help", "help"))
             {
                 return new HelpCommand().Execute();
+            }
+
+            if (key != null && key.Contains('=', StringComparison.Ordinal))
+            {
+                var list = new List<string>{ key.Substring(key.IndexOf("=", StringComparison.Ordinal) + 1) };
+                list.AddRange(value);
+                value = list; // in net7 => value.Prepend(key.Substring(key.IndexOf("=", StringComparison.Ordinal) + 1))
+                key = key.Substring(0, key.IndexOf("=", StringComparison.Ordinal));
             }
 
             if (key == null)
@@ -46,6 +55,9 @@ namespace gsudo.Commands
                     InputArguments.Global = true;
                     value = value.Where(v => !v.In("--global"));
                 }
+
+                if (value.FirstOrDefault() == "=")
+                    value = value.Skip(1);
 
                 bool reset = value.Any(v => v.In("--reset"));
                 value = value.Where(v => !v.In("--reset"));

--- a/src/gsudo/Commands/HelpCommand.cs
+++ b/src/gsudo/Commands/HelpCommand.cs
@@ -42,6 +42,8 @@ Usage:
 
 General options:
  -n | --new             Starts the command in a new console (and returns immediately).
+ --noexit               Keep elevated shell open after running {command}.
+ --noclose              When in new console, ask for keypress before closing the console.
  -w | --wait            When in new console, wait for the command to end.
 
 Security options:

--- a/src/gsudo/Commands/ServiceCommand.cs
+++ b/src/gsudo/Commands/ServiceCommand.cs
@@ -43,8 +43,11 @@ namespace gsudo.Commands
 
             Commands.HelpCommand.ShowVersion();
             Console.WriteLine();
-            if (InputArguments.Debug) await new StatusCommand().Execute().ConfigureAwait(false);
-            Console.WriteLine();
+            if (InputArguments.Debug)
+            {
+                await new StatusCommand().Execute().ConfigureAwait(false);
+                Console.WriteLine();
+            }
 
             /*
             if ((InputArguments.TrustedInstaller && !System.Security.Principal.WindowsIdentity.GetCurrent().Claims.Any(c => c.Value == Constants.TI_SID))

--- a/src/gsudo/Helpers/ArgumentsHelper.cs
+++ b/src/gsudo/Helpers/ArgumentsHelper.cs
@@ -7,6 +7,12 @@ namespace gsudo.Helpers
 {
     public static class ArgumentsHelper
     {
+        /// <summary>
+        /// Splits arguments. Quoted segments remain joined and quotes preserved.
+        /// </summary>
+        /// <example>
+        /// SplitArgs("\"my exe name\" \"my params\" OtherParam1") => new string[] { "\"my exe name\"", "\"my params\"", "OtherParam1"};
+        /// </example>
         public static IList<string> SplitArgs(string args)
         {   
             args = args.Trim();

--- a/src/gsudo/Helpers/CommandLineParser.cs
+++ b/src/gsudo/Helpers/CommandLineParser.cs
@@ -1,4 +1,5 @@
-﻿using gsudo.Commands;
+﻿using gsudo.AppSettings;
+using gsudo.Commands;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -27,7 +28,10 @@ namespace gsudo.Helpers
         public ICommand Parse()
         {
             InputArguments.Clear();
-            
+
+            if (Settings.NewWindow_Force)
+                InputArguments.NewWindow = true;
+
             // syntax: gsudo [options] [verb] [command to run]:
 
             return ParseOptions()  // Parse [options]
@@ -109,6 +113,12 @@ namespace gsudo.Helpers
             }
             else if (match("n", "--new")) { InputArguments.NewWindow = true; }
             else if (match("w", "--wait")) { InputArguments.Wait = true; }
+
+            else if (match(null, "--noexit")) { InputArguments.NoExit = true; InputArguments.KeepWindowOpen = false; }
+            else if (match(null, "--exit")) { InputArguments.NoExit = false;}
+            else if (match(null, "--noclose")) { InputArguments.KeepWindowOpen = true; InputArguments.NoExit = false; }
+            else if (match(null, "--close")) { InputArguments.KeepWindowOpen = false; }
+
             else if (match("s", "--system")) { InputArguments.RunAsSystem = true; }
             else if (match("d", "--direct")) { InputArguments.Direct = true; }
             else if (match("k", "--reset-timestamp")) { InputArguments.KillCache = true; }
@@ -145,7 +155,7 @@ namespace gsudo.Helpers
             if (args.Count == 0)
             {
                 if (InputArguments.KillCache
-                    && !InputArguments.NewWindow
+                    && (!InputArguments.NewWindow || Settings.NewWindow_Force)
                     && !InputArguments.RunAsSystem
                     && !InputArguments.Wait
                     && !InputArguments.TrustedInstaller

--- a/src/gsudo/Helpers/ExtensionMethods.cs
+++ b/src/gsudo/Helpers/ExtensionMethods.cs
@@ -120,6 +120,11 @@ namespace gsudo
 
             return result.ToString();
         }
+
+        public static bool Contains(this string source, char pattern, StringComparison comparisonType)
+        {
+            return source.IndexOf(pattern.ToString(), comparisonType) >= 0;
+        }
 #endif
     }
 }

--- a/src/gsudo/Helpers/ShellHelper.cs
+++ b/src/gsudo/Helpers/ShellHelper.cs
@@ -13,7 +13,8 @@ namespace gsudo.Helpers
         Yori,
         Wsl,
         Bash,
-        TakeCommand
+        TakeCommand,
+        WindowsApp
     }
 
     static class ShellHelper
@@ -51,7 +52,7 @@ namespace gsudo.Helpers
 
         public static bool IsIntialized { get; internal set; }
 
-         private static Shell Initialize(out string invokingShellFullPath)
+        private static Shell Initialize(out string invokingShellFullPath)
         {
             var parentProcess = Process.GetCurrentProcess().GetParentProcessExcludingShim();
 
@@ -118,6 +119,12 @@ namespace gsudo.Helpers
 
                             return Shell.PowerShellCore;
                         }
+                    }
+
+                    if (ProcessFactory.IsWindowsApp(invokingShellFullPath))
+                    {
+                        invokingShellFullPath = Environment.GetEnvironmentVariable("COMSPEC");
+                        return Shell.WindowsApp; // Called from explorer.exe, task mgr, etc.
                     }
                 }
             }

--- a/src/gsudo/InputParameters.cs
+++ b/src/gsudo/InputParameters.cs
@@ -1,4 +1,5 @@
 ﻿using gsudo.Helpers;
+using gsudo.AppSettings;
 
 namespace gsudo
 {
@@ -9,6 +10,10 @@ namespace gsudo
 
         // Open in new window
         public static bool NewWindow { get; internal set; }
+        
+        // When elevating a command, keep the elevated shell open afterwards.
+        public static bool NoExit { get; internal set; }
+        public static bool KeepWindowOpen { get; internal set; }
 
         // Wait for new process to end
         public static bool Wait { get; internal set; }


### PR DESCRIPTION
### Features:
- Added setting `gsudo config NewWindow.Force` to force every elevation in new window. Same as using `-n` every time.
- Added `--NoExit`: Keep elevated shell open after running {command}.
- Added `--NoClose`: When in new console, ask for keypress before closing the console.
- Added setting `gsudo config NewWindow.CloseBehaviour`: `OsDefault`, `KeepShellOpen` (--NoExit), PressKeyToClose(--NoClose)

- Config syntax more relaxed now:
```
gsudo.exe config loglevel debug
gsudo.exe config loglevel=debug
gsudo.exe config loglevel="debug"
gsudo.exe config loglevel =  debug
```
