### PR TITLE
Convert to Wix v4, divide installers into three packages, and update build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Installer
-        path: ./artifacts/gsudoSetup.msi
+        path: ./artifacts/gsudoSetup-*.msi
     - name: Create Release
       uses: ncipollo/release-action@v1.11.1
       with:

--- a/build/04-release-GitHub.ps1
+++ b/build/04-release-GitHub.ps1
@@ -19,17 +19,26 @@ Get-ChildItem .\artifacts\ -Filter *.pdb -Recurse | Remove-Item # Remove *.pdb o
 Compress-Archive -Path ./artifacts/x86,./artifacts/x64,./artifacts/arm64,./artifacts/net46-AnyCpu -DestinationPath "artifacts/gsudo.v$($version).zip" -force -CompressionLevel Optimal
 (Get-FileHash artifacts\gsudo.v$($version).zip).hash > artifacts\gsudo.v$($version).zip.sha256
 
-$msbuild = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+"- Cleaning bin & obj folders"
+Get-Item ".\src\gsudo.Installer\bin\", ".\src\gsudo.Installer\obj\" -ErrorAction Ignore | Remove-Item -Recurse -Force
 
-$outdir = "$PSScriptRoot\..\artifacts"
-
-"- Building Installer"
 (gc src\gsudo.Installer\Constants.Template.wxi) -replace '#VERSION#', "$version" | Out-File -encoding UTF8 src\gsudo.Installer\Constants.wxi
-& $msbuild /t:Rebuild /p:Configuration=Release src\gsudo.Installer.sln /v:Minimal /p:OutputPath=$outdir || $(popd && _exit 1)
+
+"- Building Installer arm64"
+dotnet build .\src\gsudo\gsudo.csproj -c Release -o .\artifacts -p:Platform=arm64 -v minimal -p:WarningLevel=0 || $(popd && _exit 1)
+"- Building Installer x64"
+dotnet build .\src\gsudo\gsudo.csproj -c Release -o .\artifacts -p:Platform=x64   -v minimal -p:WarningLevel=0 || $(popd && _exit 1)
+"- Building Installer x86"
+dotnet build .\src\gsudo\gsudo.csproj -c Release -o .\artifacts -p:Platform=x86   -v minimal -p:WarningLevel=0 || $(popd && _exit 1)
+
 rm .\artifacts\gsudoSetup.wixpdb
 
 "- Code Signing Installer"
-& $PSScriptRoot\03-sign.ps1 artifacts\gsudoSetup.msi || $(popd && _exit 1)
-(Get-FileHash artifacts\gsudoSetup.msi).hash > artifacts\gsudoSetup.msi.sha256
+& $PSScriptRoot\03-sign.ps1 artifacts\gsudoSetup-arm64.msi || $(popd && _exit 1)
+& $PSScriptRoot\03-sign.ps1 artifacts\gsudoSetup-x64.msi || $(popd && _exit 1)
+& $PSScriptRoot\03-sign.ps1 artifacts\gsudoSetup-x86.msi || $(popd && _exit 1)
+(Get-FileHash artifacts\gsudoSetup-arm64.msi).hash > artifacts\gsudoSetup-arm64.msi.sha256
+(Get-FileHash artifacts\gsudoSetup-x64.msi).hash > artifacts\gsudoSetup-x64.msi.sha256
+(Get-FileHash artifacts\gsudoSetupp-x86.msi).hash > artifacts\gsudoSetupp-x86.msi.sha256
 
 popd

--- a/src/gsudo.Installer.sln
+++ b/src/gsudo.Installer.sln
@@ -1,18 +1,30 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30517.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "gsudomsi", "gsudo.Installer\gsudomsi.wixproj", "{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|ARM64.Build.0 = Debug|ARM64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|x64.ActiveCfg = Debug|x64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|x64.Build.0 = Debug|x64
 		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|x86.ActiveCfg = Debug|x86
 		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Debug|x86.Build.0 = Debug|x86
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|ARM64.ActiveCfg = Release|ARM64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|ARM64.Build.0 = Release|ARM64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|x64.ActiveCfg = Release|x64
+		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|x64.Build.0 = Release|x64
 		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|x86.ActiveCfg = Release|x86
 		{34AAA3CF-95E5-41EA-8A00-C5F713BF664E}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/src/gsudo.Installer/Constants.Template.wxi
+++ b/src/gsudo.Installer/Constants.Template.wxi
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Include>
+﻿<Include xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <?define Version="#VERSION#" ?>
 </Include>

--- a/src/gsudo.Installer/Product.wxs
+++ b/src/gsudo.Installer/Product.wxs
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?if $(sys.BUILDARCH) = "arm64"?>
+  <?define installerVer = "500"?>
+  <?else?>
+  <?define installerVer = "400"?>
+  <?endif?>
 
-  <Product Id="*" Name="gsudo v$(env.version)" Language="1033" Version="$(env.version_MajorMinorPatch)"
-           UpgradeCode="567b5616-d362-484e-b6ff-7c1875cf0aee" Manufacturer="Gerardo Grignoli">
+  <Package Name="gsudo v$(env.version)" Language="1033" Version="$(env.version_MajorMinorPatch)" UpgradeCode="567b5616-d362-484e-b6ff-7c1875cf0aee" Manufacturer="Gerardo Grignoli" InstallerVersion="$(installerVer)">
 
-	  <Package InstallerVersion="200"
-             Compressed="yes"
-             InstallScope="perMachine"
-             Manufacturer="Gerardo Grignoli"
-             Description="gsudo is a sudo-equivalent for windows" />
-	  
+    <SummaryInformation Description="gsudo is a sudo-equivalent for windows" />
+
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
 
@@ -18,129 +17,106 @@
       <ComponentGroupRef Id="GSudo" />
     </Feature>
 
-    <UIRef Id="WixUI_InstallDir" />
-	
-	<!-- Skip license dialog -->
-	<UI>
-		<Publish Dialog="WelcomeDlg"
-				 Control="Next"
-				 Event="NewDialog"
-				 Value="InstallDirDlg"
-				 Order="2">1</Publish>
-		<Publish Dialog="InstallDirDlg"
-				 Control="Back"
-				 Event="NewDialog"
-				 Value="WelcomeDlg"
-				 Order="2">1</Publish>
-	</UI>				 
-	
-    <WixVariable Id="WixUILicenseRtf" Value="..\..\vendor\LICENSE.rtf" />
+    <ui:WixUI Id="WixUI_InstallDir" />
+
+    <!-- Skip license dialog -->
+    <UI>
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
+    </UI>
+
+    <WixVariable Id="WixUILicenseRtf" Value="vendor\LICENSE.rtf" />
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
     <InstallExecuteSequence>
-	  <!-- https://stackoverflow.com/a/17608049/97471 -->
-      <Custom Action="CreateSudoExeLink" Before="InstallFinalize">NOT Installed</Custom>
-      <Custom Action="RemoveSudoExeLink" After="InstallInitialize">Installed AND NOT REINSTALL</Custom>
-	  <Custom Action="CreateSudoCurrentFolderLink" Before="InstallFinalize">NOT Installed</Custom>
-      <Custom Action="RemoveSudoCurrentFolderLink" After="InstallInitialize">Installed AND NOT REINSTALL</Custom>
-		
-	  <Custom Action="RemoveInstallFolder" After="InstallInitialize">REMOVE AND NOT UPGRADINGPRODUCTCODE</Custom>
-	</InstallExecuteSequence>
+      <!-- https://stackoverflow.com/a/17608049/97471 -->
+      <Custom Action="CreateSudoExeLink" Before="InstallFinalize" Condition="NOT Installed" />
+      <Custom Action="RemoveSudoExeLink" After="InstallInitialize" Condition="Installed AND NOT REINSTALL" />
+      <Custom Action="CreateSudoCurrentFolderLink" Before="InstallFinalize" Condition="NOT Installed" />
+      <Custom Action="RemoveSudoCurrentFolderLink" After="InstallInitialize" Condition="Installed AND NOT REINSTALL" />
+      <Custom Action="RemoveInstallFolder" After="InstallInitialize" Condition="REMOVE AND NOT UPGRADINGPRODUCTCODE" />
+    </InstallExecuteSequence>
+  </Package>
 
-  </Product>
+  <Fragment>
+    <StandardDirectory Id="ProgramFiles6432Folder">
+      <Directory Id="INSTALLFOLDER" Name="gsudo">
+        <Directory Id="VERSIONFOLDER" Name="$(env.version)"/>
+      </Directory>
+    </StandardDirectory>
+  </Fragment>
 
   <Fragment>
     <ComponentGroup Id="GSudo">
       <ComponentRef Id="GSudoPath" />
+
+      <?if $(sys.BUILDARCH) = "x64"?>
       <ComponentRef Id="GSudoExe" />
+      <?elseif $(sys.BUILDARCH) = "x86"?>
       <ComponentRef Id="GSudoExeX86" />
+      <?elseif $(sys.BUILDARCH) = "arm64"?>
       <ComponentRef Id="GSudoExeARM64" />
-	  <ComponentRef Id="GSudoBash" />
-	  <ComponentRef Id="GSudoPowerShell" />
-	</ComponentGroup>
+      <?else?>
+      <?error Platform $(sys.BUILDARCH) is not supported?>
+      <?endif?>
+
+      <ComponentRef Id="GSudoBash" />
+      <ComponentRef Id="GSudoPowerShell" />
+      <ComponentRef Id="GSudoModule" />
+      <ComponentRef Id="InvokeGSudo" />
+    </ComponentGroup>
   </Fragment>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="gsudo">
-		  <Directory Id="VERSIONFOLDER" Name="$(env.version)">
-
-          <Component Id="GSudoPath" Guid="923f225a-75cd-4fca-ad48-a4161187f7a4">
-            <CreateFolder />
-            <Environment Id="SET_ENV" Action="set" Name="PATH" Part="last" Permanent="no" System="yes"
-                         Value="[INSTALLFOLDER]Current" />
-          </Component>
-
-          <Component Id="GSudoExe" Guid="">
-            <Condition>
-              <![CDATA[(VersionNT64) AND NOT(%PROCESSOR_ARCHITECTURE~="ARM64")]]>
-            </Condition>
-            <File Id="GSudoExe" KeyPath="yes" Name="gsudo.exe" Source="..\..\artifacts\x64\gsudo.exe"/>
-          </Component>
-
-          <Component Id="GSudoExeARM64" Guid="bec137e1-06e2-4efb-aea9-30306cc01c85">
-            <Condition>
-              <![CDATA[(VersionNT64) AND (%PROCESSOR_ARCHITECTURE~="ARM64")]]>
-            </Condition>
-            <File Id="GSudoExeARM64" KeyPath="yes" Name="gsudo.exe" Source="..\..\artifacts\arm64\gsudo.exe"/>
-          </Component>
-
-          <Component Id="GSudoExeX86" Guid="">
-            <Condition>
-              <![CDATA[NOT(VersionNT64)]]>
-            </Condition>
-            <File Id="GSudoExeX86" KeyPath="yes" Name="gsudo.exe" Source="..\..\artifacts\x86\gsudo.exe" />
-          </Component>
-
-          <Component Id="GSudoBash" Guid="3d6047df-a14c-484d-9ded-77761d03197a">
-            <File Id="GSudoBash" KeyPath="yes" Name="gsudo" Source="..\..\artifacts\x64\gsudo" />
-          </Component>
-
-          <Component Id="GSudoPowerShell" Guid="99d35b52-4b20-42d3-afad-11a98cab2fd3">
-            <File Id="GSudoModuleDef" KeyPath="no" 	Name="gsudoModule.psd1" Source="..\..\artifacts\x64\gsudoModule.psd1" />
-            <File Id="GSudoModule" KeyPath="yes" 	Name="gsudoModule.psm1" Source="..\..\artifacts\x64\gsudoModule.psm1" />
-            <File Id="InvokeGSudo" KeyPath="no" 	Name="invoke-gsudo.ps1" Source="..\..\artifacts\x64\invoke-gsudo.ps1" />
-          </Component>
-			  
-		  </Directory>
-        </Directory>
-      </Directory>
-    </Directory>
+    <Launch Message="This package is not intended for your platform. Please select the relevant package." Condition="(VersionNT64) AND NOT(%PROCESSOR_ARCHITECTURE~=&quot;ARM64&quot;)"/>
+    <Component Id="GSudoExe" Directory="INSTALLFOLDER">
+      <File Id="GSudoExe" Name="gsudo.exe" Source="..\..\artifacts\x64\gsudo.exe" />
+    </Component>
   </Fragment>
 
   <Fragment>
-    <CustomAction Id="CreateSudoExeLink"
-                  Directory="VERSIONFOLDER"
-                  ExeCommand='cmd /c mklink sudo.exe "[VERSIONFOLDER]gsudo.exe"'
-                  Execute="deferred"
-                  Return="ignore"
-                  Impersonate="no" />
-    <CustomAction Id="RemoveSudoExeLink"
-                  Directory="VERSIONFOLDER"
-                  ExeCommand='cmd /c DEL sudo.exe'
-                  Execute="deferred"
-                  Return="ignore"
-                  Impersonate="no" />
+    <Launch Message="This package is not intended for your platform. Please select the relevant package." Condition="(VersionNT64) AND (%PROCESSOR_ARCHITECTURE~=&quot;ARM64&quot;)"/>
+    <Component Id="GSudoExeARM64" Directory="INSTALLFOLDER">
+      <File Id="GSudoExeARM64" Name="gsudo.exe" Source="..\..\artifacts\arm64\gsudo.exe" />
+    </Component>
+  </Fragment>
 
-	  <CustomAction Id="CreateSudoCurrentFolderLink"
-					Directory="INSTALLFOLDER"
-					ExeCommand='cmd /c mklink /J "[INSTALLFOLDER]Current" "[VERSIONFOLDER]"'
-					Execute="deferred"
-					Return="ignore"
-					Impersonate="no" />
-	  <CustomAction Id="RemoveSudoCurrentFolderLink"
-					Directory="INSTALLFOLDER"
-					ExeCommand='cmd /c RD /S /Q "[INSTALLFOLDER]Current"'
-					Execute="deferred"
-					Return="ignore"
-					Impersonate="no" />
-	  <CustomAction Id="RemoveInstallFolder"
-					Directory="INSTALLFOLDER"
-					ExeCommand='cmd /c RD /S /Q "[INSTALLFOLDER]"'
-					Execute="deferred"
-					Return="ignore"
-					Impersonate="no" />
+  <Fragment>
+    <Launch Message="This package is not intended for your platform. Please select the relevant package." Condition="NOT(VersionNT64)"/>
+    <Component Id="GSudoExeX86" Directory="INSTALLFOLDER">
+      <File Id="GSudoExeX86" Name="gsudo.exe" Source="..\..\artifacts\x86\gsudo.exe" />
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <Component Id="GSudoPath" Guid="923f225a-75cd-4fca-ad48-a4161187f7a4" Directory="INSTALLFOLDER">
+      <CreateFolder />
+      <Environment Id="SET_ENV" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[INSTALLFOLDER]Current" />
+    </Component>
+
+    <Component Id="GSudoBash" Directory="INSTALLFOLDER">
+      <File Id="GSudoBash" Name="gsudo" Source="..\..\artifacts\x64\gsudo" />
+    </Component>
+
+    <Component Id="GSudoPowerShell" Directory="INSTALLFOLDER">
+      <File Id="GSudoModuleDef" Name="gsudoModule.psd1" Source="..\..\artifacts\x64\gsudoModule.psd1" />
+    </Component>
+
+    <Component Id="GSudoModule" Directory="INSTALLFOLDER">
+      <File Id="GSudoModule" Name="gsudoModule.psm1" Source="..\..\artifacts\x64\gsudoModule.psm1" />
+    </Component>
+
+    <Component Id="InvokeGSudo" Directory="INSTALLFOLDER">
+      <File Id="InvokeGSudo" Name="invoke-gsudo.ps1" Source="..\..\artifacts\x64\invoke-gsudo.ps1" />
+    </Component>
+  </Fragment>
+
+  <Fragment>
+    <CustomAction Id="CreateSudoExeLink" Directory="VERSIONFOLDER" ExeCommand="cmd /c mklink sudo.exe &quot;[VERSIONFOLDER]gsudo.exe&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="RemoveSudoExeLink" Directory="VERSIONFOLDER" ExeCommand="cmd /c DEL sudo.exe" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="CreateSudoCurrentFolderLink" Directory="INSTALLFOLDER" ExeCommand="cmd /c mklink /J &quot;[INSTALLFOLDER]Current&quot; &quot;[VERSIONFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="RemoveSudoCurrentFolderLink" Directory="INSTALLFOLDER" ExeCommand="cmd /c RD /S /Q &quot;[INSTALLFOLDER]Current&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="RemoveInstallFolder" Directory="INSTALLFOLDER" ExeCommand="cmd /c RD /S /Q &quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
   </Fragment>
 
 </Wix>

--- a/src/gsudo.Installer/gsudomsi.wixproj
+++ b/src/gsudo.Installer/gsudomsi.wixproj
@@ -1,47 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\WiX.3.11.2\build\wix.props" Condition="Exists('..\packages\WiX.3.11.2\build\wix.props')" />
+<Project Sdk="WixToolset.Sdk/4.0.0-rc.3">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>3.10</ProductVersion>
-    <ProjectGuid>34aaa3cf-95e5-41ea-8a00-c5f713bf664e</ProjectGuid>
-    <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>gsudoSetup</OutputName>
-    <OutputType>Package</OutputType>
+    <OutputName>gsudoSetup-$(Platform)</OutputName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Release</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DefineConstants>Release</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|ARM64' ">
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|ARM64' ">
+    <DefineConstants>Release</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <WixExtension Include="WixUIExtension">
-      <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
-      <Name>WixUIExtension</Name>
-    </WixExtension>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Product.wxs" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.3" />
+    <PackageReference Include="WiX.Toolset" Version="3.9.1208.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Constants.Template.wxi" />
-    <Content Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
-  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
-  </Target>
-  <!--
-	To modify your build process, add your task inside one of the targets below and uncomment it.
-	Other similar extension points exist, see Wix.targets.
-	<Target Name="BeforeBuild">
-	</Target>
-	<Target Name="AfterBuild">
-	</Target>
-	-->
 </Project>

--- a/src/gsudo.Installer/packages.config
+++ b/src/gsudo.Installer/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="WiX" version="3.11.2" />
-  <package id="WiX.Toolset" version="3.9.1208.0" />
-</packages>


### PR DESCRIPTION
Fixes #243

With this, you probably no longer need "wixtoolset", although you will probably want to install the [HeatWave for VS2022](https://marketplace.visualstudio.com/items?itemName=FireGiant.FireGiantHeatWaveDev17) extension into your Visual Studio.

Each package will prevent itself from installing on any platform except that which it was intended for. Any of them will remove previous versions since they all share the same `UpgradeCode`.

I couldn't get the build powerscripts to run as intended, but I did manage to get everything built in order to convert and build the installers.

This leaves in place all of your existing custom actions, etc. which should continue to run as before. It also leaves in place your "install versioned and [re]point "current" (which is what is placed into the path) to it" which is a good idea for this type of utility.

Take it out for a test drive, and _disfrute_