### PR TITLE
fix call to bash wrapper `gsudo` without PATH env var set

### DIFF
--- a/src/gsudo.Wrappers/gsudo
+++ b/src/gsudo.Wrappers/gsudo
@@ -8,4 +8,4 @@
 # For better experience (fix credentials cache) in git-bash/MinGw create this wrapper can be added as function in .bashrc:
 # 		gsudo() { WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 gsudo.exe "$@"; }
 
-WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 gsudo.exe "$@"
+WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 $( dirname -- "$0")/gsudo.exe "$@"


### PR DESCRIPTION
## Problem
In WSL, when gsudo is not in `PATH` env var, the bash wrapper script cannot run because `gsudo.exe` is called without a path.

## Solution
Assuming the `gsudo` bash script will always be in the same directory as `gsudo.exe`, we can use `$( dirname -- "$0" )`. See https://stackoverflow.com/a/59916/84091