### PR TITLE
PowerShell Module Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ Alternative syntaxes:
   
   ``` Powershell
   # Add the following line to your $PROFILE 
-  Import-Module "$env:ProgramFiles\gsudo\Current\gsudoModule.psd1"
+  Import-Module "gsudoModule"
 
   # Or run:
-  Get-Command gsudoModule.psd1 | % { Write-Output "`nImport-Module `"$($_.Source)`"" | Add-Content $PROFILE }
+  Write-Output "`nImport-Module `"gsudoModule`"" | Add-Content $PROFILE
   ```
 
   - If you haven't already customized your PowerShell prompt (for example by installing Oh-My-Posh), you can easily add a red `#` indicating that the current process is elevated:

--- a/build/01-build.ps1
+++ b/build/01-build.ps1
@@ -1,4 +1,16 @@
 pushd $PSScriptRoot\..
+
+if ($env:version) {
+	"- Getting version from env:version"
+	$version = $env:version
+	$version_MajorMinorPatch=$env:version_MajorMinorPatch
+} else {
+	"- Getting version using GitVersion"
+	$env:version = $version = $(gitversion /showvariable LegacySemVer)
+	$env:version_MajorMinorPatch = $version_MajorMinorPatch=$(gitversion /showvariable MajorMinorPatch)
+}
+"- Using version number v$version / v$version_MajorMinorPatch"
+
 "-- Cleaning bin & obj folders"
 Get-Item ".\src\gsudo\bin\", ".\src\gsudo\obj\" -ErrorAction Ignore | Remove-Item -Recurse -Force 
 "-- Building net7.0 win-arm64"
@@ -23,5 +35,8 @@ cp .\src\gsudo.Wrappers\* .\artifacts\x86
 cp .\src\gsudo.Wrappers\* .\artifacts\x64
 cp .\src\gsudo.Wrappers\* .\artifacts\arm64
 cp .\src\gsudo.Wrappers\* .\artifacts\net46-AnyCpu
+
+# Set Module version number.
+Get-ChildItem .\artifacts\ -Filter gsudoModule.psd1 -Recurse | % { (Get-Content $_) -replace """0.1""", """$version_MajorMinorPatch""" | Set-Content $_.FullName }
 
 popd

--- a/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
+++ b/build/Chocolatey/gsudo/tools/chocolateyinstall.ps1
@@ -29,6 +29,11 @@ Install-ChocolateyPath -PathToInstall $SymLinkDir -PathType 'Machine'
 
 cmd /c mklink "$TargetDir\sudo.exe" "$TargetDir\gsudo.exe" 2>$null
 
+# Copy gsudoModule to "$env:ProgramFiles\PowerShell\Modules\gsudoModule"
+$PSModulesTargetDir = "$env:ProgramFiles\PowerShell\Modules\gsudoModule"
+md $PSModulesTargetDir -ErrorAction SilentlyContinue
+copy "$bin\*.ps*" $TargetDir -Exclude *.ignore -Force
+
 $OldCurrentDir = Get-Item $SymLinkDir -ErrorAction ignore
 if ($OldCurrentDir) 
 {
@@ -43,13 +48,13 @@ cmd /c mklink /d "$SymLinkDir" "$TargetDir\"
 Write-Output "gsudo successfully installed. Please restart your consoles to use gsudo.`n"
 
 if (Get-Module gsudoModule) {
-	"Please restart PowerShell to update PowerShell gsudo Module."
+	"Please restart all your PowerShell consoles to update PowerShell gsudo Module."
 } else {
 	& { 
-	"PowerShell users: To use enhanced gsudo and Invoke-Gsudo cmdlet, add the following line to your `$PROFILE"
-	"  Import-Module '$SymLinkDir\gsudoModule.psd1'"
+	"PowerShell users: Add auto-complete to  gsudo by adding the following line to your `$PROFILE"
+	"  Import-Module 'gsudoModule'"
 	"Or run: "
-	"  Write-Output `"``nImport-Module '$SymLinkDir\gsudoModule.psd1'`" | Add-Content `$PROFILE"
+	"  Write-Output `"``nImport-Module 'gsudoModule'`" | Add-Content `$PROFILE"
 
 	} 
 }

--- a/docs/docs/usage/powershell.md
+++ b/docs/docs/usage/powershell.md
@@ -164,10 +164,10 @@ gsudo -d dir C:\
   Add the following line to your $PROFILE (replace with full path)
 
   ``` powershell
-  Import-Module 'C:\FullPathTo\gsudoModule.psd1'
+  Import-Module 'gsudoModule.psd1'
 
   # Or let the following line do it for you run:
-  Get-Command gsudoModule.psd1 | % { Write-Output "`nImport-Module `"$($_.Source)`"" | Add-Content $PROFILE }
+  Write-Output "`nImport-Module `"gsudoModule`"" | Add-Content $PROFILE
   ```
 
 :::tip

--- a/installgsudo.ps1
+++ b/installgsudo.ps1
@@ -39,13 +39,14 @@ if ($process.ExitCode -ne 0)
 }
 else
 {
+	New-Item -Type Directory ($PROFILE | Split-Path) -ErrorAction SilentlyContinue
+
 	Write-Output "gsudo installed succesfully!"
 	Write-Output "Please restart your consoles to use gsudo!`n"
 	
 	"PowerShell users: To use enhanced gsudo and Invoke-Gsudo cmdlet, add the following line to your `$PROFILE"
 	"  Import-Module 'gsudoModule'"
 	"Or run: "
-	"  New-Item -Type Directory (`$PROFILE | Split-Path) -ErrorAction Ignore"
 	"  Write-Output `"``nImport-Module 'gsudoModule'`" | Add-Content `$PROFILE"
 	
 	Remove-Item $fileName 

--- a/installgsudo.ps1
+++ b/installgsudo.ps1
@@ -43,10 +43,10 @@ else
 	Write-Output "Please restart your consoles to use gsudo!`n"
 	
 	"PowerShell users: To use enhanced gsudo and Invoke-Gsudo cmdlet, add the following line to your `$PROFILE"
-	"  Import-Module '${Env:ProgramFiles}\gsudo\Current\gsudoModule.psd1'"
+	"  Import-Module 'gsudoModule'"
 	"Or run: "
 	"  New-Item -Type Directory (`$PROFILE | Split-Path) -ErrorAction Ignore"
-	"  Write-Output `"``nImport-Module '${Env:ProgramFiles}\gsudo\Current\gsudoModule.psd1'`" | Add-Content `$PROFILE"
+	"  Write-Output `"``nImport-Module 'gsudoModule'`" | Add-Content `$PROFILE"
 	
 	Remove-Item $fileName 
 }

--- a/src/gsudo.Installer/Product.wxs
+++ b/src/gsudo.Installer/Product.wxs
@@ -43,6 +43,11 @@
       <Directory Id="INSTALLFOLDER" Name="gsudo">
         <Directory Id="VERSIONFOLDER" Name="$(env.version)"/>
       </Directory>
+      <Directory Id="POWERSHELLFOLDER" Name="PowerShell">
+        <Directory Id="MODULESDIR" Name="Modules" >
+			<Directory Id="GSUDOMODULEDIR" Name="gsudoModule" />
+		</Directory>
+      </Directory>
     </StandardDirectory>
   </Fragment>
 
@@ -60,10 +65,8 @@
       <?error Platform $(sys.BUILDARCH) is not supported?>
       <?endif?>
 
-      <ComponentRef Id="GSudoBash" />
-      <ComponentRef Id="GSudoPowerShell" />
+      <ComponentRef Id="GSudoExtensions" />
       <ComponentRef Id="GSudoModule" />
-      <ComponentRef Id="InvokeGSudo" />
     </ComponentGroup>
   </Fragment>
 
@@ -94,20 +97,17 @@
       <Environment Id="SET_ENV" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[INSTALLFOLDER]Current" />
     </Component>
 
-    <Component Id="GSudoBash" Directory="VERSIONFOLDER">
+    <Component Id="GSudoExtensions" Directory="VERSIONFOLDER" Guid="923f225a-75cd-4fca-ad48-a4161187f7a5">
       <File Id="GSudoBash" Name="gsudo" Source="..\..\artifacts\x64\gsudo" />
-    </Component>
-
-    <Component Id="GSudoPowerShell" Directory="VERSIONFOLDER">
       <File Id="GSudoModuleDef" Name="gsudoModule.psd1" Source="..\..\artifacts\x64\gsudoModule.psd1" />
-    </Component>
-
-    <Component Id="GSudoModule" Directory="VERSIONFOLDER">
       <File Id="GSudoModule" Name="gsudoModule.psm1" Source="..\..\artifacts\x64\gsudoModule.psm1" />
+      <File Id="InvokeGSudo" Name="invoke-gsudo.ps1" Source="..\..\artifacts\x64\invoke-gsudo.ps1" />
     </Component>
 
-    <Component Id="InvokeGSudo" Directory="VERSIONFOLDER">
-      <File Id="InvokeGSudo" Name="invoke-gsudo.ps1" Source="..\..\artifacts\x64\invoke-gsudo.ps1" />
+    <Component Id="GSudoModule" Directory="GSUDOMODULEDIR" Guid="923f225a-75cd-4fca-ad48-a4161187f7a6">
+      <File Id="GSudoModulePsd1" Name="gsudoModule.psd1" Source="..\..\artifacts\x64\gsudoModule.psd1" />
+      <File Id="GSudoModulePsm1" Name="gsudoModule.psm1" Source="..\..\artifacts\x64\gsudoModule.psm1" />
+      <File Id="GSudoModuleFn" Name="invoke-gsudo.ps1" Source="..\..\artifacts\x64\invoke-gsudo.ps1" />
     </Component>
   </Fragment>
 
@@ -120,3 +120,4 @@
   </Fragment>
 
 </Wix>
+	

--- a/src/gsudo/Commands/BangBangCommand.cs
+++ b/src/gsudo/Commands/BangBangCommand.cs
@@ -16,8 +16,7 @@ namespace gsudo.Commands
         {
             if (ShellHelper.InvokingShell.In (Shell.PowerShell, Shell.PowerShellCore, Shell.PowerShellCore623BuggedGlobalInstall))
             {
-                var module = Path.Combine(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), "gsudoModule.psd1");
-                throw new ApplicationException($"To use `gsudo !!` from powershell, run or add the following line to your `$PROFILE:\n\n Import-Module '{ module }'");
+                throw new ApplicationException($"To use `gsudo !!` from PowerShell, run or add the following line to your PowerShell $PROFILE:\n\n Import-Module 'gsudoModule'");
             }
 
             var caller = Process.GetCurrentProcess().GetShellProcess().MainModule.ModuleName;


### PR DESCRIPTION
Improvements to gsudo PowerShell Module:
-  The Wix (msi) installer will deploy PowerShell gsudoModule to '%ProgramFiles%\PowerShell\Modules\gsudoModule\', so `Import-Module gsudoModule` does not requires an absolute path anymore
-  The `Chocolatey` installer also will deploy PowerShell gsudoModule to '%ProgramFiles%\PowerShell\Modules\gsudoModule\'
-  The module version number is now properly updated with the build version.
- Updated docs to suggest `Import-Module gsudoModule` instead of the absolute path.