### PR TITLE
Improve `gsudo status` (exit code and json output)

### DIFF
--- a/src/gsudo/Commands/StatusCommand.cs
+++ b/src/gsudo/Commands/StatusCommand.cs
@@ -1,4 +1,4 @@
-﻿using gsudo.Helpers;
+using gsudo.Helpers;
 using gsudo.Native;
 using gsudo.Rpc;
 using System;
@@ -56,13 +56,13 @@ namespace gsudo.Commands
                     if (val is string)
                         Console.WriteLine(val);
                     else
-                    {                        
+                    {
                         Console.WriteLine(GetJsonValue(val));
                     }
                 }
                 else
                 {
-                    throw new ApplicationException($"\"{Key}\" is not a valid Status Key. Valid keys are: {String.Join(", ", result.Keys.ToArray() )}");
+                    throw new ApplicationException($"\"{Key}\" is not a valid Status Key. Valid keys are: {String.Join(", ", result.Keys.ToArray())}");
                 }
             }
             else if (AsJson)
@@ -98,14 +98,14 @@ namespace gsudo.Commands
             {
                 var sb = new StringBuilder();
                 sb.Append($"[");
-                bool first=true;
+                bool first = true;
                 foreach (string s in Value as string[])
                 {
-                    if(!first)
+                    if (!first)
                         sb.Append(", ");
 
                     first = false;
-                    sb.Append(GetJsonValue(s)); 
+                    sb.Append(GetJsonValue(s));
                 }
                 sb.Append($"]");
                 return sb.ToString();


### PR DESCRIPTION
- Returns exit code 1, if `filter` is one of `CacheAvailable`, `IsElevated`, or `IsAdminMember` and the corresponding value is false.
- For `--json` it uses `IntegrityLevelNumeric` and `IntegrityLevel` also for the process list, to be consistent with the main result; without `--json` it still uses the same format ("name (number)") as in the main result.

Refers to https://github.com/gerardog/gsudo/issues/236
Enhances https://github.com/gerardog/gsudo/pull/276