### PR TITLE
Improve gsudo scripting scenarios

### DIFF
--- a/docs/docs/tips/script-self-elevation.md
+++ b/docs/docs/tips/script-self-elevation.md
@@ -7,81 +7,132 @@ hide_title: true
 
 ## Self Elevate Script
 
-You may want to create a script that always runs elevated. This template detects if the session is not elevated, then calls itself elevated using gsudo.
+You may want to create a script that always runs elevated. The following scripts will detect if the session is not elevated and then call themselves using gsudo.
 
-It uses `gsudo status` to test if we are elevated, because alternatives such as using `whoami` varies upon OS language, and `net session` breaks when network is down.
+Prefer using `gsudo status` to test if the session is elevated, as alternatives such as `whoami` vary depending on the OS language, and `net session` may fail when the network is down.
 
-Batch: (e.g. `SelfElevate.bat`)
+- Cmd Batch file, long version: (e.g. `self-elevate.bat`) [link](https://github.com/gerardog/gsudo/tree/master/sample-scripts/self-elevate.cmd)
 
-``` batch
-@echo off
-gsudo status | findstr /C:"Admin: True" 1> nul 2>nul && goto :IsAdmin
-echo You are not admin. Elevating using gsudo.
-gsudo "%~f0" %*
-if errorlevel 999 Echo Failed to elevate.
-exit /b %errorlevel%
+  ``` batch
+  @echo off
+  gsudo status IsElevated --no-output && goto :IsElevated
 
-:IsAdmin
-:: You are admin. Do admin stuff here.
-```
+  echo Admin rights needed. Elevating using gsudo.
+  gsudo "%~f0" %*
+  if errorlevel 999 Echo Failed to elevate!
+  exit /b %errorlevel%
 
-One-Line version:
+  :IsElevated
+  :: You are elevated here. Do admin stuff.
+  ```
 
-``` batch
-gsudo status | findstr /C:"Admin: True" 1> nul 2>nul || gsudo "%~f0" && exit /b
-:: You are admin. Do admin stuff here.
-```
+- One-Line version: [link](https://github.com/gerardog/gsudo/tree/master/sample-scripts/self-elevate-one-liner.cmd)
 
-PowerShell: (e.g. `SelfElevate.ps1`)
+  ``` batch
+  @gsudo status IsElevated --no-output || (gsudo "%~f0" & exit /b)
+  :: You are elevated here. Do admin stuff.
+  ```
 
-```powershell
-function Test-IsAdmin {
-  return (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-}
+- PowerShell: (e.g. `self-elevate.ps1`) [link](https://github.com/gerardog/gsudo/tree/master/sample-scripts/self-elevate.ps1)
 
-if ((Test-IsAdmin) -eq $false) {
- Write-Warning "This script requires local admin privileges. Elevating..."
- gsudo "& '$($MyInvocation.MyCommand.Source)'" $args
- if ($LastExitCode -eq 999 ) {
-    Write-error 'Failed to elevate.'
- }
- return
-}
+  ```powershell
+  function Test-IsElevated {
+    return (New-Object Security.Principal.WindowsPrincipal(
+      [Security.Principal.WindowsIdentity]::GetCurrent()))
+      .IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+  }
 
-# You are admin. Do admin stuff here.
-```
+  if ((Test-IsElevated) -eq $false) {
+    Write-Warning "This script requires local admin privileges. Elevating..."
+    gsudo "& '$($MyInvocation.MyCommand.Source)'" $args
+    if ($LastExitCode -eq 999 ) {
+      Write-error 'Failed to elevate.'
+    }
+    return
+  }
+
+  # You are elevated. Do admin stuff here.
+  ```
+
+  If you don't have gsudo installed, you can still self-elevate but in a new console window: [link](https://github.com/gerardog/gsudo/tree/master/sample-scripts/self-elevate-without-gsudo.cmd)
+
+  ``` batch
+  @echo off
+  :: This script performs self-elevation, in a new console using only built-in windows tools.
+  :: Detect elevation using 'net session', jump to :ElevatedTasks if we are admin.
+  net session >nul 2>nul & net session >nul 2>nul && goto :ElevatedTasks
+  echo Admin rights needed. Elevating using powershell...
+
+  :: This powershell command re-executes this script in a new elevated console
+  powershell -C start-Process "%~f0" -Verb RunAs -ArgumentList \"%* \""
+  IF ERRORLEVEL 1 Echo Elevation failed!
+  exit /b
+
+  :ElevatedTasks
+  :: You are elevated here. Add your admin tasks here.
+  :: This will run as admin ::
+  ```
 
 ## Detect if running elevated
 
-PowerShell:
+- PowerShell-native method:
 
-``` powershell
-function Test-IsAdmin {
-  return (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-}
-```
+  ``` powershell
+  function Test-IsElevated {
+    return (New-Object Security.Principal.WindowsPrincipal(
+      [Security.Principal.WindowsIdentity]::GetCurrent()))
+      .IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+  }
+  ```
 
 Even when this code **looks like** it will check if the current user is member of the local admins group (regardless of current elevation status), instead it just returns `$true` if elevated.
 
+- PowerShell gsudo method:
+
+  ``` PowerShell
+  $IsElevated = 'true' -eq (gsudo status IsElevated)
+  ```
+
+- Cmd Batch:
+
+  ``` batch
+  gsudo status IsElevated --no-output 
+  if errorlevel 0 echo Current Process Is Not Elevated
+  if errorlevel 1 echo Current Process Is Elevated
+  ```
+
 ## Detect if current user is member of admins group (regardless of current elevation status)
 
-If you want to know if the current user can elevate with a UAC popup but without entering other user credentials. If so, we need to check if the user is a member of S-1-5-32-544 (a.k.a. BUILTIN\Administrators for english OS).
+If you want to know if the current user can elevate with a UAC popup but without entering other user credentials, you need to check if the user is a member of S-1-5-32-544 (a.k.a. BUILTIN\Administrators for english OS).
 
-Batch:
+- Batch with gsudo:
 
-``` batch
-whoami /groups | findstr S-1-5-32-544 > nul
-if errorlevel 1 goto IsAdmin
-echo Not Admin
-exit /b
-:IsAdmin
-echo Current user is a member of the Local Admins group. But we don't know if this session is elevated.
-```
+  ``` batch
+  gsudo status IsAdminMember --no-output 
+  if errorlevel 1 goto IsAdminMember
+  ```
 
-PowerShell:
+- Batch without gsudo:
 
-``` powershell
-function Test-IsMemberOfLocalAdminsGroup {
- ([System.Security.Principal.WindowsIdentity]::GetCurrent()).Claims.Value -contains "S-1-5-32-544"
-}
-```
+  ``` batch
+  whoami /groups | findstr S-1-5-32-544 > nul
+  if errorlevel 1 goto IsAdmin
+  echo Not Admin
+  exit /b
+  :IsAdmin
+  echo Current user is a member of the Local Admins group. But we don't know if this session is elevated.
+  ```
+
+- PowerShell Native
+
+  ``` powershell
+  function Test-IsMemberOfLocalAdminsGroup {
+  ([System.Security.Principal.WindowsIdentity]::GetCurrent()).Claims.Value -contains "S-1-5-32-544"
+  }
+  ```
+
+- PowerShell with gsudo
+
+  ``` PowerShell
+  $IsAdminMember = 'true' -eq (gsudo status IsAdminMember)
+  ```

--- a/sample-scripts/many-elevations-using-gsudo-cache.cmd
+++ b/sample-scripts/many-elevations-using-gsudo-cache.cmd
@@ -1,0 +1,36 @@
+:: This script demonstrates how to use gsudo cache to 
+:: perform a mix of unelevated and elevated tasks
+:: showing only one UAC popup.
+
+@echo off
+
+echo.
+echo This is a Demo Computer Clean-up script designed to be executed monthly or at intervals of a few months.
+echo WARNING: THIS SCRIPT WILL DELETE YOUR TEMPORARY FILES! Press Ctrl-C to abort or reject the User Access Control window!
+pause
+
+:: Start a cache. with max idle time of 5 minutes.
+gsudo --loglevel Error cache on --duration 00:05:00
+if errorlevel 999 echo Failed to elevate. Aborting Script & exit /b
+
+echo Cleaning up Windows temporary files... (Elevation required)
+gsudo del /s /q "C:\Windows\Temp\*.*" 
+
+echo.
+echo Cleaning up current user temporary files... (No elevation required)
+for /d %%x in ("%USERPROFILE%\AppData\Local\Temp\*") do @rd /s /q "%%x"
+
+echo.
+echo Cleaning up Internet Explorer cache...  (No elevation required)
+for /d %%x in ("%USERPROFILE%\AppData\Local\Microsoft\Windows\INetCache\*") do @rd /s /q "%%x"
+
+:: echo.
+:: echo Emptying the Recycle Bin for the all users:
+:: gsudo del /s /q "%SystemDrive%\$Recycle.Bin\*.*" 
+
+echo.
+echo Clean-up completed successfully!
+
+:: close gsudo cache, silently
+gsudo --loglevel Error cache off
+

--- a/sample-scripts/many-elevations-using-gsudo-cache.ps1
+++ b/sample-scripts/many-elevations-using-gsudo-cache.ps1
@@ -1,0 +1,32 @@
+# This script demonstrates how to use gsudo cache to 
+# perform a mix of unelevated and elevated tasks
+# showing only one UAC popup.
+
+Write-Host "This is a Demo Computer Clean-up script designed to be executed monthly or at intervals of a few months.
+WARNING: THIS SCRIPT WILL DELETE YOUR TEMPORARY FILES! Press Ctrl-C to abort or reject the User Access Control window!" -ForegroundColor Yellow
+Read-Host "Press Enter to continue..."
+
+# Start a cache. with max idle time of 5 minutes.
+gsudo --loglevel Error cache on --duration "00:05:00" 
+if ($LASTEXITCODE -ge 999) { Write-Host "Failed to elevate. Aborting Script."; exit }
+
+# Clear the temporary files
+Write-Host "Cleaning up Windows temporary files... (Elevation required)" -ForegroundColor Yellow
+gsudo { 
+	Get-ChildItem "C:\Windows\Temp\*" | Remove-Item -Force -ErrorAction SilentlyContinue -Recurse
+	Get-ChildItem "C:\Users\*\AppData\Local\Temp\*" | Remove-Item -Force -ErrorAction SilentlyContinue -Recurse
+}
+
+# Clear the Internet Explorer cache
+Write-Host "Cleaning up Internet Explorer cache..." -ForegroundColor Yellow
+gsudo {
+	Remove-Item "C:\Users\*\AppData\Local\Microsoft\Windows\INetCache\*" -Recurse -ErrorAction SilentlyContinue
+}
+
+# Write-Host "`nEmptying the Recycle Bin for all users:" -ForegroundColor Yellow
+# gsudo { Remove-Item -Path "$env:SystemDrive\$Recycle.Bin\*.*" -Recurse -Force }
+
+Write-Host "Clean-up completed successfully!`n" -ForegroundColor Yellow
+
+# close gsudo cache, silently
+gsudo --loglevel Error cache off

--- a/sample-scripts/readme.md
+++ b/sample-scripts/readme.md
@@ -1,0 +1,21 @@
+# gsudo Sample Scripts
+
+This folder contains sample scripts demonstrating how to use `gsudo` to elevate privileges on a Windows machine. The provided scripts include:
+
+1. **Script Self-Elevation:** A technique to ensure that the current script is running elevated, by detecting when it is not, and elevating itself. More details can be found in the [gsudo documentation on script self-elevation](https://gerardog.github.io/gsudo/docs/tips/script-self-elevation).
+
+    - [`self-elevate.cmd`](./self-elevate.cmd): Batch script version
+    - [`self-elevate-one-liner.cmd`](./self-elevate-one-liner.cmd): A one-liner version of the batch script.
+    - [`self-elevate.ps1`](./self-elevate.ps1): PowerShell version.
+    - [`self-elevate-without-gsudo.cmd`](./self-elevate-without-gsudo.cmd): Example without using `gsudo`.
+
+2. **Many Elevations Using gsudo Cache:**
+
+    - [`many-elevations-using-gsudo-cache.cmd`](./many-elevations-using-gsudo-cache.cmd): Batch script version
+    - [`many-elevations-using-gsudo-cache.ps1`](./many-elevations-using-gsudo-cache.ps1): PowerShell version
+
+3. **Don't show an UAC pop-up:** Perform an elevated admin task if and only if it can be done without an interactive UAC pop-up. (i.e. when already elevated or gsudo cache is active)
+    - [`silent-elevation-one-liner.cmd`](./silent-elevation-one-liner.cmd): A one-liner version.
+    - [`silent-elevation.cmd`](./silent-elevation.cmd): Verbose version .
+
+These scripts are examples and should be used with caution. Always review and understand the code you are executing on your system.

--- a/sample-scripts/self-elevate-one-liner.cmd
+++ b/sample-scripts/self-elevate-one-liner.cmd
@@ -1,0 +1,2 @@
+@gsudo status IsElevated --no-output || (gsudo "%~f0" & exit /b)
+:: You are elevated here. Do admin stuff.

--- a/sample-scripts/self-elevate-without-gsudo.cmd
+++ b/sample-scripts/self-elevate-without-gsudo.cmd
@@ -1,0 +1,27 @@
+@echo off
+:: This script performs self-elevation, in a new console using only built-in windows tools.
+
+:: detect elevation using 'net session', jump to :ElevatedTasks if we are admin.
+net session >nul 2>nul & net session >nul 2>nul && goto :ElevatedTasks
+echo Admin rights needed. Elevating using powershell...
+
+:: This powershell command re-executes this script a new elevated console
+powershell -C start-Process "%~f0" -Verb RunAs -ArgumentList \"%* \""
+
+:: To make the caller script wait for the elevated tasks to end add the "-Wait" option, like:
+:: powershell -C start-Process "%~f0" -Verb RunAs -ArgumentList \"%* \"" -Wait
+
+IF ERRORLEVEL 1 Echo Elevation failed!
+
+:: make the unelevated script end.
+exit /b
+
+:ElevatedTasks
+:: You are elevated here. Add your admin tasks here.
+:: This will run as admin ::
+
+:: For demo purposes, show I am elevated: (a.k.a. High Mandatory Level)
+whoami /groups | findstr /i "S-1-16-"
+
+:: For demo purposes, prevent the elevated window from closing too fast:
+pause 

--- a/sample-scripts/self-elevate.cmd
+++ b/sample-scripts/self-elevate.cmd
@@ -1,0 +1,10 @@
+@echo off
+gsudo status IsElevated --no-output && goto :IsElevated
+
+echo Admin rights needed. Elevating using gsudo.
+gsudo "%~f0" %*
+if errorlevel 999 Echo Failed to elevate!
+exit /b %errorlevel%
+
+:IsElevated
+:: You are elevated here. Do admin stuff.

--- a/sample-scripts/self-elevate.ps1
+++ b/sample-scripts/self-elevate.ps1
@@ -1,0 +1,14 @@
+function Test-IsAdmin {
+  return (New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if ((Test-IsAdmin) -eq $false) {
+ Write-Warning "This script requires local admin privileges. Elevating..."
+ gsudo "& '$($MyInvocation.MyCommand.Source)'" $args
+ if ($LastExitCode -eq 999 ) {
+    Write-error 'Failed to elevate.'
+ }
+ return
+}
+
+# You are elevated here. Do admin stuff.

--- a/sample-scripts/silent-elevation-one-liner.cmd
+++ b/sample-scripts/silent-elevation-one-liner.cmd
@@ -1,0 +1,10 @@
+:: This script demonstrates how to use gsudo to perform an elevated admin task 
+:: if and only if it can be done without an interactive UAC pop-up
+@(gsudo status IsElevated --no-output || gsudo status CacheAvailable --no-output) || (echo Running as non admin and no gsudo cache available. Aborting... && exit /b)
+
+:: Write your task here.
+
+:: It's not guaranted to be running as admin! But prepend gsudo to elevate a command without a UAC, by using the existing cache.
+
+:: For example, elevate gsudo status, using gsudo, to get the status after elevation.
+gsudo "gsudo status"

--- a/sample-scripts/silent-elevation.cmd
+++ b/sample-scripts/silent-elevation.cmd
@@ -1,0 +1,37 @@
+:: This script demonstrates how to use gsudo to perform an elevated admin task 
+:: if and only if it can be done without an interactive UAC pop-up
+
+@echo off
+
+:: Set this value to the worst possible execution time of this script
+set CACHE_DURATION=00:01:00 
+
+:: If we are elevated, we can do admin stuff directly.
+gsudo status IsElevated --no-output && Echo - Running as Admin? Yes && goto :run-script
+Echo - Running as Admin? No
+
+:: Check if there is a gsudo credentials cache available, so elevation is possible.
+gsudo status CacheAvailable --no-output || echo - No gsudo cache available: Aborting.. && exit /b
+
+:: Extending cache duration for the max amount of time this script could run to ensure the cache remains.
+Echo - Found gsudo cache available: Extending cache duration to ensure cache is available during all the execution of this script.
+set using-cache=1
+
+gsudo --loglevel error Cache on --duration %CACHE_DURATION%
+if errorlevel 0 echo - Extended gsudo cache duration successfully && goto :run-script
+if errorlevel 1 echo - Failed to extend gsudo cache duration. Aborting... && exit /b
+
+:run-script
+
+echo - Executing script
+echo.
+:: Write your task here.
+:: It's not running as admin: Prepend gsudo to elevate a command using the existing cache.
+
+:: For example here I am elevating a call to gsudo status, getting the elevation status after elevation.
+gsudo gsudo status 
+
+:: Cleanup
+if "%using-cache%"=="1" echo - Stopping gsudo cache...
+if "%using-cache%"=="1" gsudo --loglevel none cache off 
+set using-cache=

--- a/src/gsudo.Wrappers/gsudoModule.psm1
+++ b/src/gsudo.Wrappers/gsudoModule.psm1
@@ -82,7 +82,7 @@ https://github.com/gerardog/gsudo
 }
 
 function Test-IsGsudoCacheAvailable {
-    [bool]((& 'gsudo.exe' status) -like "*Available for this process: True*")
+    return ('true' -eq (gsudo status CacheAvailable))
 }
 
 function Test-IsProcessElevated {
@@ -146,7 +146,7 @@ if ($gsudoAutoComplete) {
         'CopyNetworkShares'           = $TrueFalseReset;
         'PowerShellLoadProfile'       = $TrueFalseReset;
         'SecurityEnforceUacIsolation' = $TrueFalseReset;
-		'Status'                      = @('--json', 'CallerPid', 'UserName', 'UserSid', 'IsElevated', 'IsAdminMember', 'IntegrityLevelNumeric', 'IntegrityLevel', 'CacheMode', 'CacheAvailable', 'CacheSessionsCount', 'CacheSessions', 'IsRedirected')
+		'Status'                      = @('--json', 'CallerPid', 'UserName', 'UserSid', 'IsElevated', 'IsAdminMember', 'IntegrityLevelNumeric', 'IntegrityLevel', 'CacheMode', 'CacheAvailable', 'CacheSessionsCount', 'CacheSessions', 'IsRedirected', '--no-output')
         '--user'                      = @("$env:USERDOMAIN\$env:USERNAME");
         '-u'                          = @("$env:USERDOMAIN\$env:USERNAME")
     }

--- a/src/gsudo/Commands/CacheCommand.cs
+++ b/src/gsudo/Commands/CacheCommand.cs
@@ -64,7 +64,7 @@ namespace gsudo.Commands
                     if (InputArguments.Debug) commandToRun.Add("--debug");
 
                     commandToRun.AddRange(new[]
-                        {"cache", "on", "--pid", AllowedPid.ToString()});
+                        {"--loglevel", Settings.LogLevel.ToString() ,"cache", "on", "--pid", AllowedPid.ToString(), "--duration", Settings.TimeSpanWithInfiniteToString(CacheDuration ?? Settings.CacheDuration)});
 
                     InputArguments.Wait = true;
                     InputArguments.Direct = true;
@@ -117,15 +117,15 @@ An active credentials cache session, is a running elevated instance of gsudo tha
             Console.WriteLine($@"
 Usage:
 ------
-gsudo cache {{on | off}} [-p {{pid}}] [-d {{time}}]   Start/stop a gsudo cache session.
-  -p | --pid {{pid}}            Specify which process can use the cache. (Use 0 for any, Default=caller pid)
-  -d | --duration {{hh:mm:ss}}  Max time the cache can stay idle before closing. 
-                              Use '-1' to keep open until logoff (or `cache off`, or `-k`).
-                              Current idle duration is: {Settings.CacheDuration.GetStringValue()}
+gsudo cache {{on | off}} [-p {{pid}}] [-d {{time}}]	Start/stop a gsudo cache session.
+ -p, --pid {{pid}}			Specify which process can use the cache. (Use 0 for any, Default=caller pid)
+ -d, --duration {{hh | hh:mm | hh:mm:ss}}	Sets the maximum idle time for the cache before termination. 
+					Use '-1' to keep open until logoff (or `cache off`, or `-k`).
+					Current idle duration is: {Settings.CacheDuration.GetStringValue()}
 
-gsudo -k                       Stops all active cache sessions.
-gsudo status                   Shows info regarding the user, elevation, and cache status
-gsudo config CacheMode {{mode}}  Change the cache mode. 
+gsudo -k			Stops all active cache sessions.
+gsudo status			Shows info regarding the user, elevation, and cache status
+gsudo config CacheMode {{mode}}	Change the cache mode. 
 
 Available Cache Modes:
   * Disabled: Every elevation shows a UAC popup. 

--- a/src/gsudo/Commands/HelpCommand.cs
+++ b/src/gsudo/Commands/HelpCommand.cs
@@ -37,7 +37,8 @@ Usage:
  gsudo [options]\t\t\tElevates your current shell
  gsudo [options] {command} [args]\tRuns {command} with elevated permissions
  gsudo cache [on | off | help] \t\tStarts/Stops an elevated cache session. (reduced UAC popups)
- gsudo status [key] [--json]\t\tShows current user, cache and console status. Can be filtered by [key].
+ gsudo status [--json]\t\t\tShows current user, cache and console status. 
+ gsudo status {key} [--no-output]\tShows status filtered by json {key}. Boolean keys also returned as exit codes.
  gsudo !!\t\t\t\tRe-run last command as admin. (YMMV)
 
 New Window options:

--- a/src/gsudo/Helpers/CommandLineParser.cs
+++ b/src/gsudo/Helpers/CommandLineParser.cs
@@ -222,6 +222,8 @@ namespace gsudo.Helpers
                     arg = DeQueueArg();
                     if (arg.In("--json"))
                         cmd.AsJson = true;
+                    else if (arg.In("--no-output"))
+                        cmd.NoOutput = true;
                     else if(string.IsNullOrEmpty(cmd.Key))
                         cmd.Key = arg;
                     else throw new ApplicationException($"Invalid option: {arg}");


### PR DESCRIPTION
- `gsudo status {key}` returns exit code for booleans: 0(success) for true, 1(fail) for false
- Added sample usage scripts and docs
- Fixed issue on Cache ON not propagating loglevel or duration if cache was already active
