### PR TITLE
Docs: Include Nushell on homepage

### DIFF
--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -33,7 +33,7 @@ const FeatureList = [
     description: (
       <>
         Detects your shell and elevates your command as a native shell command.
-        Currently supports <code>CMD</code>, <code>PowerShell</code>, <code>WSL</code>, <code>MinGW/Git-Bash</code>, <code>MSYS2</code>, <code>Cygwin</code>,<code>Yori</code> and <code>Take Command</code>.
+        Currently supports <code>CMD</code>, <code>PowerShell</code>, <code>WSL</code>, <code>MinGW/Git-Bash</code>, <code>MSYS2</code>, <code>Cygwin</code>, <code>Nushell</code>, <code>Yori</code> and <code>Take Command</code>.
       </>
     ),
   },  {


### PR DESCRIPTION
Include Nushell on homepage given support following #154.

---

I’m unsure on order, so I just put Nushell where we were missing a space already. Feel free to request an order change.

I went looking for Nushell support after not seeing it on the homepage.