### PR TITLE
Fix `Error: Invalid option: -noninteractive` using `gsudo {command}` on Visual Studio code

### DIFF
--- a/src/gsudo/Helpers/CommandLineParser.cs
+++ b/src/gsudo/Helpers/CommandLineParser.cs
@@ -79,6 +79,7 @@ namespace gsudo.Helpers
                     if (c != null)
                         return c;
                 }
+                else if (arg.In("-noninteractive")) { } // ignore due to gerardog/gsudo#305
                 else if (arg.StartsWith("-", StringComparison.OrdinalIgnoreCase)
                             && arg.NotIn("-encodedCommand")) // -encodedCommand is not posix compliant, but is what powershell sends on: gsudo { script block }
                                                              // So treat -encodedCommand as part of the CommandToRun, for gerardog/gsudo#160

--- a/src/gsudo/Helpers/CommandToRunAdapter.cs
+++ b/src/gsudo/Helpers/CommandToRunAdapter.cs
@@ -1,15 +1,12 @@
 ﻿using gsudo.Native;
-using Microsoft.VisualBasic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace gsudo.Helpers
 {
@@ -133,7 +130,7 @@ namespace gsudo.Helpers
                         if (!Settings.PowerShellLoadProfile)
                             newArgs.Add("-NoProfile");
 
-                        if (args[0] == "-encodedCommand")
+                        if (args[0].In("-encodedCommand", "-noninteractive"))
                         {
                             newArgs.AddRange(args);
                         }


### PR DESCRIPTION
Fixes #305