### PR TITLE
Fix typo in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,6 +28,6 @@ Before creating one, please search  https://github.com/gerardog/gsudo/issues?q=
 ## Context:
   - Windows version:
 <!-- To get Windows version, press Win+R, type `winver` and press enter.
-     For example:   Win11 21H2 - Spanish  -> 
+     For example:   Win11 21H2 - Spanish  --> 
   - gsudo version:      
 <!-- Run `gsudo -v` to get gsudo version -->


### PR DESCRIPTION
I've just open an issue and saw that `gsudo version` of the template was invisible in the rendered issue. This is due to a typo in a HTML comment. This PR fixes the typo.