### PR TITLE
Release v2.4.3

### DIFF
--- a/src/gsudo.Wrappers.Tests/Invoke-gsudo.Tests.ps1
+++ b/src/gsudo.Wrappers.Tests/Invoke-gsudo.Tests.ps1
@@ -43,7 +43,7 @@ Describe "PS Invoke-Gsudo (PSv$($PSVersionTable.PSVersion.Major))" {
 	}
 
 	It "It throws with .Net Exceptions" {
-		{ Invoke-gsudo { [int]::Parse('foo') } } | Should -throw "*Input string was not*"
+		{ Invoke-gsudo { [int]::Parse('foo') } } | Should -throw "*nput string*"
 	}
 	
 	It "It throws when ErrorAction = Stop" {

--- a/src/gsudo.Wrappers/gsudo
+++ b/src/gsudo.Wrappers/gsudo
@@ -8,4 +8,5 @@
 # For better experience (fix credentials cache) in git-bash/MinGw create this wrapper can be added as function in .bashrc:
 # 		gsudo() { WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 gsudo.exe "$@"; }
 
-WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 "$( dirname -- "$0")/gsudo.exe" "$@"
+thisdir="$(dirname "$(readlink "$0")")"
+WSLENV=WSL_DISTRO_NAME:USER:$WSLENV MSYS_NO_PATHCONV=1 "${thisdir}/gsudo.exe" "$@"

--- a/src/gsudo/AppSettings/Settings.cs
+++ b/src/gsudo/AppSettings/Settings.cs
@@ -127,8 +127,14 @@ namespace gsudo
         {
             if (value.In("-1", "Infinite"))
                 return TimeSpan.MaxValue;
-            else
-                return TimeSpan.Parse(value, CultureInfo.InvariantCulture);
+
+            var timeSpan = TimeSpan.Parse(value, CultureInfo.InvariantCulture);
+
+            // Cap at 24 days.
+            if (timeSpan.TotalDays > 24)
+                return TimeSpan.MaxValue;
+
+            return timeSpan;
         }
 
         internal static string TimeSpanWithInfiniteToString(TimeSpan value)

--- a/src/gsudo/AppSettings/Settings.cs
+++ b/src/gsudo/AppSettings/Settings.cs
@@ -82,7 +82,7 @@ namespace gsudo
 
         public static RegistrySetting<string> ExceptionList { get; } =
             new RegistrySetting<string>(nameof(ExceptionList),
-                defaultValue: "notepad.exe;powershell.exe;whoami.exe;",
+                defaultValue: "notepad.exe;powershell.exe;whoami.exe;vim.exe;nano.exe;",
                 deserializer: (string s)=>s,
                 scope: RegistrySettingScope.GlobalOnly);
 

--- a/src/gsudo/Commands/RunCommand.cs
+++ b/src/gsudo/Commands/RunCommand.cs
@@ -231,7 +231,7 @@ namespace gsudo.Commands
             }
         }
 
-        internal static bool IsRunningAsDesiredUser()
+        internal static bool IsRunningAsDesiredUser(bool allowHigherIntegrity = false)
         {
             if (InputArguments.TrustedInstaller && !WindowsIdentity.GetCurrent().Claims.Any(c => c.Value == Constants.TI_SID))
                 return false;
@@ -239,7 +239,10 @@ namespace gsudo.Commands
             if (InputArguments.RunAsSystem && !WindowsIdentity.GetCurrent().IsSystem)
                 return false;
 
-            if ((int)InputArguments.GetIntegrityLevel() != SecurityHelper.GetCurrentIntegrityLevel())
+            if ((int)InputArguments.GetIntegrityLevel() != SecurityHelper.GetCurrentIntegrityLevel() && !allowHigherIntegrity)
+                return false;
+
+            if ((int)InputArguments.GetIntegrityLevel() > SecurityHelper.GetCurrentIntegrityLevel())
                 return false;
 
             if (InputArguments.UserName != null && InputArguments.UserName != WindowsIdentity.GetCurrent().Name)

--- a/src/gsudo/Commands/ServiceCommand.cs
+++ b/src/gsudo/Commands/ServiceCommand.cs
@@ -55,7 +55,7 @@ namespace gsudo.Commands
                 || (InputArguments.RunAsSystem && !System.Security.Principal.WindowsIdentity.GetCurrent().IsSystem)
                 || (InputArguments.UserName != null && !SecurityHelper.IsAdministrator() && SecurityHelper.IsMemberOfLocalAdmins()) 
                 )*/
-            if (!RunCommand.IsRunningAsDesiredUser())
+            if (!RunCommand.IsRunningAsDesiredUser(allowHigherIntegrity: true))
             {
                 Logger.Instance.Log("This service is not running with desired credentials. Starting a new service instance.", LogLevel.Info);
 #if DEBUG

--- a/src/gsudo/Commands/ServiceCommand.cs
+++ b/src/gsudo/Commands/ServiceCommand.cs
@@ -28,6 +28,8 @@ namespace gsudo.Commands
 
         void EnableTimer()
         {
+            if (CacheDuration > TimeSpan.FromDays(24)) CacheDuration = TimeSpan.FromDays(24);
+
             if (CacheDuration != TimeSpan.MaxValue) 
                 ShutdownTimer.Change((int)CacheDuration.TotalMilliseconds, Timeout.Infinite);
         }

--- a/src/gsudo/Commands/StatusCommand.cs
+++ b/src/gsudo/Commands/StatusCommand.cs
@@ -152,7 +152,7 @@ namespace gsudo.Commands
 
             foreach (string s in result["CacheSessions"] as string[])
             {
-                Console.WriteLine($"    {s},");
+                Console.WriteLine($"    {s}");
             }
 
             if ((bool)result["IsRedirected"])

--- a/src/gsudo/Helpers/ServiceHelper.cs
+++ b/src/gsudo/Helpers/ServiceHelper.cs
@@ -69,8 +69,8 @@ namespace gsudo.Helpers
         private static ServiceLocation FindServiceByIntegrity(int? clientPid, string user)
         {
             var anyIntegrity = InputArguments.UserName != null;
-            var tryHighIntegrity = !InputArguments.IntegrityLevel.HasValue || InputArguments.IntegrityLevel.Value >= IntegrityLevel.High;
-            var tryLowIntegrity = !InputArguments.IntegrityLevel.HasValue || InputArguments.IntegrityLevel.Value < IntegrityLevel.High;
+            var tryHighIntegrity = !InputArguments.IntegrityLevel.HasValue || InputArguments.IntegrityLevel.Value > IntegrityLevel.Medium;
+            var tryLowIntegrity = !InputArguments.IntegrityLevel.HasValue || InputArguments.IntegrityLevel.Value <= IntegrityLevel.Medium;
 
             var targetUserSid = InputArguments.RunAsSystem ? "S-1-5-18" : InputArguments.UserSid;
 

--- a/src/gsudo/Native/NativeMethods.cs
+++ b/src/gsudo/Native/NativeMethods.cs
@@ -1,11 +1,10 @@
-﻿using gsudo.Native;
-using System;
+﻿using System;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using static gsudo.Native.TokensApi;
 
-namespace gsudo.Tokens
+namespace gsudo.Native
 {
     internal static partial class NativeMethods
     {
@@ -21,19 +20,19 @@ namespace gsudo.Tokens
         internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
         internal const int ERROR_NOT_ALL_ASSIGNED = 0x00000514;
 
-        internal const UInt32 STANDARD_RIGHTS_REQUIRED = 0x000F0000;
-        internal const UInt32 STANDARD_RIGHTS_READ = 0x00020000;
-        internal const UInt32 TOKEN_ASSIGN_PRIMARY = 0x0001;
-        internal const UInt32 TOKEN_DUPLICATE = 0x0002;
-        internal const UInt32 TOKEN_IMPERSONATE = 0x0004;
-        internal const UInt32 TOKEN_QUERY = 0x0008;
-        internal const UInt32 TOKEN_QUERY_SOURCE = 0x0010;
-        internal const UInt32 TOKEN_ADJUST_PRIVILEGES = 0x0020;
-        internal const UInt32 TOKEN_ADJUST_GROUPS = 0x0040;
-        internal const UInt32 TOKEN_ADJUST_DEFAULT = 0x0080;
-        internal const UInt32 TOKEN_ADJUST_SESSIONID = 0x0100;
-        internal const UInt32 TOKEN_READ = (STANDARD_RIGHTS_READ | TOKEN_QUERY);
-        internal const UInt32 TOKEN_ALL_ACCESS = (STANDARD_RIGHTS_REQUIRED |
+        internal const uint STANDARD_RIGHTS_REQUIRED = 0x000F0000;
+        internal const uint STANDARD_RIGHTS_READ = 0x00020000;
+        internal const uint TOKEN_ASSIGN_PRIMARY = 0x0001;
+        internal const uint TOKEN_DUPLICATE = 0x0002;
+        internal const uint TOKEN_IMPERSONATE = 0x0004;
+        internal const uint TOKEN_QUERY = 0x0008;
+        internal const uint TOKEN_QUERY_SOURCE = 0x0010;
+        internal const uint TOKEN_ADJUST_PRIVILEGES = 0x0020;
+        internal const uint TOKEN_ADJUST_GROUPS = 0x0040;
+        internal const uint TOKEN_ADJUST_DEFAULT = 0x0080;
+        internal const uint TOKEN_ADJUST_SESSIONID = 0x0100;
+        internal const uint TOKEN_READ = STANDARD_RIGHTS_READ | TOKEN_QUERY;
+        internal const uint TOKEN_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
                             TOKEN_ASSIGN_PRIMARY |
                             TOKEN_DUPLICATE |
                             TOKEN_IMPERSONATE |
@@ -42,7 +41,7 @@ namespace gsudo.Tokens
                             TOKEN_ADJUST_PRIVILEGES |
                             TOKEN_ADJUST_GROUPS |
                             TOKEN_ADJUST_DEFAULT |
-                            TOKEN_ADJUST_SESSIONID);
+                            TOKEN_ADJUST_SESSIONID;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern IntPtr GetCurrentProcess();
@@ -65,7 +64,13 @@ namespace gsudo.Tokens
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern Boolean CloseHandle(IntPtr hObject);
+        internal static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetKernelObjectSecurity(IntPtr Handle, uint securityInformation, IntPtr pSecurityDescriptor, uint nLength, out uint lpnLengthNeeded);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool SetKernelObjectSecurity(IntPtr Handle, uint securityInformation, IntPtr pSecurityDescriptor);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct LUID
@@ -100,5 +105,20 @@ namespace gsudo.Tokens
 
             public LUID_AND_ATTRIBUTES[] Privileges { get => privileges; set => privileges = value; }
         }
+
     }
+
+    [Flags]
+    internal enum SECURITY_INFORMATION : uint
+    {
+        OWNER_SECURITY_INFORMATION = 0x00000001,
+        GROUP_SECURITY_INFORMATION = 0x00000002,
+        DACL_SECURITY_INFORMATION = 0x00000004,
+        SACL_SECURITY_INFORMATION = 0x00000008,
+        UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000,
+        UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000,
+        PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000,
+        PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+    }
+
 }

--- a/src/gsudo/Native/ProcessApi.cs
+++ b/src/gsudo/Native/ProcessApi.cs
@@ -122,6 +122,9 @@ namespace gsudo.Native
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern bool CloseHandle(IntPtr hObject);
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr LocalFree(IntPtr hMem);
+
         [DllImport("kernel32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         internal static extern bool GetExitCodeProcess(Microsoft.Win32.SafeHandles.SafeProcessHandle processHandle, out int exitCode);
 
@@ -190,6 +193,8 @@ namespace gsudo.Native
         #region Query Process Info
         public const UInt32 PROCESS_QUERY_INFORMATION = 0x0400;
         public const UInt32 PROCESS_SET_INFORMATION = 0x0200;
+        public const UInt32 READ_CONTROL = 0x00020000;
+        public const UInt32 WRITE_DAC = 0x40000;
 
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern IntPtr OpenProcess(UInt32 dwDesiredAccess, Boolean bInheritHandle, UInt32 dwProcessId);
@@ -225,7 +230,7 @@ namespace gsudo.Native
         internal static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, SECURITY_ATTRIBUTES lpPipeAttributes, int nSize);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        internal static extern uint ResumeThread(IntPtr hThread);
+        internal static extern int ResumeThread(IntPtr hThread);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -233,5 +238,16 @@ namespace gsudo.Native
 
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool DuplicateHandle(
+            IntPtr hSourceProcessHandle,
+            IntPtr hSourceHandle,
+            IntPtr hTargetProcessHandle,
+            out IntPtr lpTargetHandle,
+            uint dwDesiredAccess,
+            [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+            uint dwOptions);
     }
 }

--- a/src/gsudo/Native/SafeTokenHandle.cs
+++ b/src/gsudo/Native/SafeTokenHandle.cs
@@ -21,4 +21,19 @@ namespace gsudo.Native
             return Native.ProcessApi.CloseHandle(base.handle);
         }
     }
+
+    internal sealed class SafeThreadHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        internal SafeThreadHandle(IntPtr handle)
+            : base(true)
+        {
+            base.SetHandle(handle);
+        }
+
+        override protected bool ReleaseHandle()
+        {
+            return Native.ProcessApi.CloseHandle(handle);
+        }
+
+    }
 }

--- a/src/gsudo/Native/TokensApi.cs
+++ b/src/gsudo/Native/TokensApi.cs
@@ -414,7 +414,19 @@ namespace gsudo.Native
         #endregion
 
         [DllImport("Advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(string StringSecurityDescriptor, uint StringSDRevision, out IntPtr SecurityDescriptor, out UIntPtr SecurityDescriptorSize);
+        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+            string StringSecurityDescriptor, 
+            uint StringSDRevision, 
+            out IntPtr SecurityDescriptor, 
+            out UIntPtr SecurityDescriptorSize);
 
+        // Additional imports for DACL manipulation
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool ConvertSecurityDescriptorToStringSecurityDescriptor(
+            IntPtr SecurityDescriptor,
+            uint StringSDRevision,
+            SECURITY_INFORMATION SecurityInformation,
+            out IntPtr StringSecurityDescriptor,
+            out uint StringSecurityDescriptorLen);
     }
 }

--- a/src/gsudo/ProcessRenderers/TokenSwitchRenderer.cs
+++ b/src/gsudo/ProcessRenderers/TokenSwitchRenderer.cs
@@ -4,8 +4,10 @@ using gsudo.Rpc;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,8 +21,8 @@ namespace gsudo.ProcessRenderers
     {
         private readonly Connection _connection;
         private readonly ElevationRequest _elevationRequest;
-        private readonly SafeProcessHandle _process;
-        private readonly ProcessApi.PROCESS_INFORMATION _processInformation;
+        private readonly SafeProcessHandle _processHandle;
+        private readonly SafeHandle _threadHandle;
         private readonly ManualResetEventSlim tokenSwitchSuccessEvent = new ManualResetEventSlim(false);
 
         internal TokenSwitchRenderer(Connection connection, ElevationRequest elevationRequest)
@@ -55,9 +57,9 @@ namespace gsudo.ProcessRenderers
                 args = elevationRequest.Arguments;
             }
 
-            _process = ProcessFactory.CreateProcessAsUserWithFlags(exeName, args, dwCreationFlags, out _processInformation);
+            ProcessFactory.CreateProcessForTokenReplacement(exeName, args, dwCreationFlags, out _processHandle, out _threadHandle, out int processId);
 
-            elevationRequest.TargetProcessId = _processInformation.dwProcessId;
+            elevationRequest.TargetProcessId = processId;
             if (!elevationRequest.NewWindow)
                 ConsoleApi.SetConsoleCtrlHandler(ConsoleHelper.IgnoreConsoleCancelKeyPress, true);
         }
@@ -68,7 +70,7 @@ namespace gsudo.ProcessRenderers
             {
                 var t1 = new StreamReader(_connection.ControlStream).ConsumeOutput(HandleControlStream);
 
-                WaitHandle.WaitAny(new WaitHandle[] { tokenSwitchSuccessEvent.WaitHandle, _process.GetProcessWaitHandle(), _connection.DisconnectedWaitHandle });
+                WaitHandle.WaitAny(new WaitHandle[] { tokenSwitchSuccessEvent.WaitHandle, _processHandle.GetProcessWaitHandle(), _connection.DisconnectedWaitHandle });
 
                 if (!tokenSwitchSuccessEvent.IsSet)
                 {
@@ -87,43 +89,34 @@ namespace gsudo.ProcessRenderers
                 _connection.DataStream.Close();
                 _connection.ControlStream.Close();
 
-                return GetResult();
-            }
-            finally
-            {
-                ConsoleApi.SetConsoleCtrlHandler(ConsoleHelper.IgnoreConsoleCancelKeyPress, false);
-            }
-        }
+                if (ProcessApi.ResumeThread(_threadHandle.DangerousGetHandle()) < 0)
+                    throw new Win32Exception();
 
-        public void TerminateProcess()
-        {
-            ProcessApi.TerminateProcess(_process.DangerousGetHandle(), 0);
-        }
-
-        public Task<int> GetResult()
-        {
-            try
-            {
-                _ = ProcessApi.ResumeThread(_processInformation.hThread);
-                Native.FileApi.CloseHandle(_processInformation.hThread);
+                _threadHandle.Close();
 
                 if (_elevationRequest.Wait)
                 {
-                    _process.GetProcessWaitHandle().WaitOne();
-                    if (ProcessApi.GetExitCodeProcess(_process, out int exitCode))
+                    _processHandle.GetProcessWaitHandle().WaitOne();
+                    if (ProcessApi.GetExitCodeProcess(_processHandle, out int exitCode))
                         return Task.FromResult(exitCode);
 
-                    Native.FileApi.CloseHandle(_processInformation.hProcess);
+                    _processHandle.Close();
                 }
 
                 return Task.FromResult(0);
             }
             finally
             {
+                _processHandle?.Close();
+                _threadHandle?.Close();
                 ConsoleApi.SetConsoleCtrlHandler(ConsoleHelper.IgnoreConsoleCancelKeyPress, false);
             }
         }
 
+        public void TerminateProcess()
+        {
+            ProcessApi.TerminateProcess(_processHandle.DangerousGetHandle(), 0);
+        }
 
         enum Mode { Normal, Error};
         Mode CurrentMode = Mode.Normal;

--- a/src/gsudo/Rpc/NamedPipeNameFactory.cs
+++ b/src/gsudo/Rpc/NamedPipeNameFactory.cs
@@ -16,7 +16,8 @@ namespace gsudo.Rpc
             var s = InputArguments.RunAsSystem ? "_S" : string.Empty;
             var admin = !isAdmin ? "_NonAdmin" : string.Empty;
 
-            var data = $"allowedSid-{allowedSid}_targetSid-{targetSid}{allowedPid}{s}{ti}{admin}";
+            var ownExe = GetHash(ProcessHelper.GetOwnExeName());
+            var data = $"allowedSid-{allowedSid}_targetSid-{targetSid}{allowedPid}{s}{ti}{admin}_{ownExe}";
 #if !DEBUG
             data = GetHash(data);
 #endif

--- a/src/gsudo/Tokens/PrivilegeManager.cs
+++ b/src/gsudo/Tokens/PrivilegeManager.cs
@@ -3,7 +3,8 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using static gsudo.Native.TokensApi;
-using static gsudo.Tokens.NativeMethods;
+using static gsudo.Native.NativeMethods;
+using gsudo.Native;
 
 namespace gsudo.Tokens
 {

--- a/src/gsudo/Tokens/TokenSwitcher.cs
+++ b/src/gsudo/Tokens/TokenSwitcher.cs
@@ -3,6 +3,8 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using gsudo.Helpers;
 using gsudo.Native;
+using static gsudo.Native.TokensApi;
+using static gsudo.Native.NativeMethods;
 
 namespace gsudo.Tokens
 {
@@ -28,19 +30,42 @@ namespace gsudo.Tokens
                     .EnablePrivilege(Privilege.SeIncreaseQuotaPrivilege, false)
                     .Impersonate(() =>
                     {
-                        IntPtr hProcess = ProcessApi.OpenProcess(ProcessApi.PROCESS_SET_INFORMATION, true,
-                            (uint)elevationRequest.TargetProcessId);
-                        NtDllApi.PROCESS_INFORMATION_CLASS processInformationClass =
-                            NtDllApi.PROCESS_INFORMATION_CLASS.ProcessAccessToken;
+                        IntPtr securityDescriptor = IntPtr.Zero;
+                        UIntPtr securityDescriptorSize = UIntPtr.Zero;
+                        IntPtr hProcess = IntPtr.Zero;
+                        try
+                        {
+                            hProcess = ProcessApi.OpenProcess(ProcessApi.PROCESS_SET_INFORMATION | ProcessApi.PROCESS_QUERY_INFORMATION | ProcessApi.READ_CONTROL | ProcessApi.WRITE_DAC, true,
+                                (uint)elevationRequest.TargetProcessId);
 
-                        int res = NtDllApi.NativeMethods.NtSetInformationProcess(hProcess, processInformationClass,
-                            ref tokenInfo,
-                            Marshal.SizeOf<NtDllApi.PROCESS_ACCESS_TOKEN>());
-                        Logger.Instance.Log($"NtSetInformationProcess returned {res}", LogLevel.Debug);
-                        if (res < 0)
-                            throw new Win32Exception();
+                            // Tighten the security descriptor of the process to elevate, before elevating its process token
+                            string sddl = "D:(D;;GAFAWD;;;S-1-1-0)S:(ML;;NW;;;HI)"; // Deny all to everyone. SACL requires High Integrity.
+                            Native.TokensApi.ConvertStringSecurityDescriptorToSecurityDescriptor(sddl, StringSDRevision: 1, out securityDescriptor, out securityDescriptorSize);
 
-                        ProcessApi.CloseHandle(hProcess);
+                            // https://learn.microsoft.com/en-us/windows/win32/secauthz/low-level-security-descriptor-functions
+                            if (!SetKernelObjectSecurity(hProcess, (uint)SECURITY_INFORMATION.DACL_SECURITY_INFORMATION, securityDescriptor))
+                                throw new InvalidOperationException("Failed to tighten security descriptor.", new Win32Exception());
+
+                            // Replace the Process access token with an elevated one.
+                            var processInformationClass = NtDllApi.PROCESS_INFORMATION_CLASS.ProcessAccessToken;
+
+                            int res = NtDllApi.NativeMethods.NtSetInformationProcess(hProcess, processInformationClass,
+                                ref tokenInfo, Marshal.SizeOf<NtDllApi.PROCESS_ACCESS_TOKEN>());
+
+                            if (res < 0)
+                                throw new Win32Exception();
+
+                            Logger.Instance.Log($"Process token replaced", LogLevel.Debug);
+                        }
+                        finally
+                        {
+                            if (hProcess != IntPtr.Zero)
+                                ProcessApi.CloseHandle(hProcess);
+
+                            // Cleanup: Free the security descriptor pointer if it's not null
+                            if (securityDescriptor != IntPtr.Zero)
+                                ProcessApi.LocalFree(securityDescriptor);
+                        }
                     });
             }
             finally

--- a/src/gsudo/gsudo.csproj
+++ b/src/gsudo/gsudo.csproj
@@ -42,6 +42,12 @@
     <None Remove="bin\**" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Remove="Tokens\PrivilegeManager.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Tokens\PrivilegeManager.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Restricted process and thread handles in TokenSwitchMode.
* Restricted ACL of the elevated process to High Integrity.
* Fixed issue elevating to MediumPlus integrity level
* Add workaround for vim and nano. Fixes #248 #302
* Fix error when user configures CacheDuration > 24 days. Fixes #318
* Fix Issue when multiple simultaneous gsudo versions throw `Unauthorized. (Different gsudo.exe?)`. Fixes #300
* Fix PowerShell Unit Tests for Pwsh v7.4