### PR TITLE
add askpass named pipe support (GSUDO_ASKPASS_NAMED_PIPE)

### DIFF
--- a/src/gsudo/Helpers/ServiceHelper.cs
+++ b/src/gsudo/Helpers/ServiceHelper.cs
@@ -170,7 +170,19 @@ namespace gsudo.Helpers
             {
                 if (InputArguments.UserName != WindowsIdentity.GetCurrent().Name)
                 {
-                    var password = ConsoleHelper.ReadConsolePassword(InputArguments.UserName);
+                    SecureString password;
+
+                    string pipeName = Environment.GetEnvironmentVariable("GSUDO_ASKPASS_NAMED_PIPE");
+
+                    if (!string.IsNullOrEmpty(pipeName))
+                    {
+                        password = ConsoleHelper.ReadPasswordFromNamedPipe(pipeName);
+                    }
+                    else
+                    {
+                        password = ConsoleHelper.ReadConsolePassword(InputArguments.UserName);
+                    }
+
                     ret = ProcessFactory.StartWithCredentials(ownExe, commandLine, InputArguments.UserName, password).GetSafeProcessHandle();
                 }
                 else


### PR DESCRIPTION
We're integrating gsudo in Remote Desktop Manager, and one thing we're missing is a way to inject the password to launch the process as another user. One way [we've done this in the past](https://github.com/Devolutions/openssh-distro/blob/master/patches/v9.5.0/0004-add-askpass-named-pipe-support.patch) was to patch software to accept a named pipe name through an optional environment variable, and treat it as an "askpass" named pipe that just serves the password once. The named pipe is only used as a replacement for the current prompt if the GSUDO_ASKPASS_NAMED_PIPE environment variable has been set.

Alternatively, we could add a command-line parameter to pass the optional "askpass named pipe" name, but we're happy with just this environment variable, unless you wish to have it changed or done differently.