### PR TITLE
Make installer to point `sudo.exe` symlink at `Current` directory

### DIFF
--- a/src/gsudo.Installer/Product.wxs
+++ b/src/gsudo.Installer/Product.wxs
@@ -30,9 +30,9 @@
 
     <InstallExecuteSequence>
       <!-- https://stackoverflow.com/a/17608049/97471 -->
+      <Custom Action="CreateSudoCurrentFolderLink" Before="InstallFinalize" Condition="NOT Installed" />
       <Custom Action="CreateSudoExeLink" Before="InstallFinalize" Condition="NOT Installed" />
       <Custom Action="RemoveSudoExeLink" After="InstallInitialize" Condition="Installed AND NOT REINSTALL" />
-      <Custom Action="CreateSudoCurrentFolderLink" Before="InstallFinalize" Condition="NOT Installed" />
       <Custom Action="RemoveSudoCurrentFolderLink" After="InstallInitialize" Condition="Installed AND NOT REINSTALL" />
       <Custom Action="RemoveInstallFolder" After="InstallInitialize" Condition="REMOVE AND NOT UPGRADINGPRODUCTCODE" />
     </InstallExecuteSequence>
@@ -112,8 +112,8 @@
   </Fragment>
 
   <Fragment>
-    <CustomAction Id="CreateSudoExeLink" Directory="VERSIONFOLDER" ExeCommand="cmd /c mklink sudo.exe &quot;[VERSIONFOLDER]gsudo.exe&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
-    <CustomAction Id="RemoveSudoExeLink" Directory="VERSIONFOLDER" ExeCommand="cmd /c DEL sudo.exe" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="CreateSudoExeLink" Directory="VERSIONFOLDER" ExeCommand="cmd /c mklink sudo.exe &quot;[INSTALLFOLDER]Current\gsudo.exe&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
+    <CustomAction Id="RemoveSudoExeLink" Directory="INSTALLFOLDER" ExeCommand="cmd /c DEL &quot;[INSTALLFOLDER]Current\sudo.exe&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
     <CustomAction Id="CreateSudoCurrentFolderLink" Directory="INSTALLFOLDER" ExeCommand="cmd /c mklink /J &quot;[INSTALLFOLDER]Current&quot; &quot;[VERSIONFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
     <CustomAction Id="RemoveSudoCurrentFolderLink" Directory="INSTALLFOLDER" ExeCommand="cmd /c RD /S /Q &quot;[INSTALLFOLDER]Current&quot;" Execute="deferred" Return="ignore" Impersonate="no" />
     <CustomAction Id="RemoveInstallFolder" Directory="INSTALLFOLDER" ExeCommand="cmd /c RD /S /Q &quot;[INSTALLFOLDER]&quot;" Execute="deferred" Return="ignore" Impersonate="no" />


### PR DESCRIPTION
Have the symlink point at the `Current` junction directory instead of the specific installed folder.

To do this, have to create the junction before the symlink (and upon uninstall do it in the opposite order).

Fixes #390