### PR TITLE
fix askpass named pipe name path prefix

### DIFF
--- a/src/gsudo/Helpers/ConsoleHelper.cs
+++ b/src/gsudo/Helpers/ConsoleHelper.cs
@@ -126,11 +126,10 @@ namespace gsudo.Helpers
 
         internal static SecureString ReadPasswordFromNamedPipe(string pipeName)
         {
-            string pipePath = @"\\.\pipe\" + pipeName;
-
             try
             {
-                using (var pipeClient = new NamedPipeClientStream(".", pipePath, PipeDirection.In))
+                // named pipe name should *not* include \\.\pipe\ path prefix
+                using (var pipeClient = new NamedPipeClientStream(".", pipeName, PipeDirection.In))
                 {
                     pipeClient.Connect();
 


### PR DESCRIPTION
In my original pull request (https://github.com/gerardog/gsudo/pull/388) adding support for the GSUDO_ASKPASS_NAMED_PIPE environment variable, I made a minor mistake: the named pipe name should *not* include the \\.\pipe\ path prefix.

Here is how to properly test this feature:

Save this to an AskpassNamedPipeServer.ps1 file:
```powershell
param (
    [string] $PipeName = "MyNamedPipe",
    [string] $Password = "MySecretPassword"
)

$FullPipeName = "\\.\pipe\$PipeName"
$PipeServer = New-Object System.IO.Pipes.NamedPipeServerStream($PipeName, [System.IO.Pipes.PipeDirection]::Out)

Write-Host "Waiting for client to connect to the pipe '$FullPipeName'..."

$PipeServer.WaitForConnection()
$StreamWriter = New-Object System.IO.StreamWriter($PipeServer)
$StreamWriter.WriteLine($Password)
$StreamWriter.Flush()
$StreamWriter.Close()
$PipeServer.Close()

Write-Host "Password sent through the named pipe and connection closed."
```

Open a PowerShell terminal, and launch the script:

```powershell
.\AskpassNamedPipeServer.ps1 "MyNamedPipe" "MySecretPassword"
```

In another terminal, launch gsudo.exe with the `-u` parameter for a valid user, setting the GSUDO_ASKPASS_NAMED_PIPE environment variable to point to your named pipe:

```powershell
$Env:GSUDO_ASKPASS_NAMED_PIPE="MyNamedPipe"
.\gsudo.exe -u validuser
```

If everything worked, you should see the named pipe server printing out that it "served" the password and closed. gsudo checks if the user exists first, so it will only try to read from the named pipe if the user exists.