### PR TITLE
Fix errorlevel not being mantained after postcommands

### DIFF
--- a/src/gsudo/Helpers/CommandToRunAdapter.cs
+++ b/src/gsudo/Helpers/CommandToRunAdapter.cs
@@ -397,10 +397,7 @@ namespace gsudo.Helpers
         
             if (keepWindowOpen && !IsWindowsApp)
             {
-                // Using "`& pause " makes cmd eat the exit code
-                postCommands.Add("set errl = !ErrorLevel!");
                 postCommands.Add("pause");
-                postCommands.Add("exit /b !errl!");
             }
 
             string startupFolder = InputArguments.StartingDirectory ?? Environment.CurrentDirectory;
@@ -419,6 +416,12 @@ namespace gsudo.Helpers
 
             if (mustWrap || preCommands.Any() || postCommands.Any())
             {
+				if (postCommands.Any())
+				{
+					// Any post command will eat the exit code, we need to mantain
+					postCommands.Insert(0, "set errl = !ErrorLevel!");
+					postCommands.Add("exit /b !errl!");
+				}
                 var all = preCommands
                             .Concat(new[] { string.Join(" ", command) })
                             .Concat(postCommands);

--- a/src/gsudo/Helpers/CommandToRunAdapter.cs
+++ b/src/gsudo/Helpers/CommandToRunAdapter.cs
@@ -418,8 +418,8 @@ namespace gsudo.Helpers
             {
 				if (postCommands.Any())
 				{
-					// Any post command will eat the exit code, we need to mantain
-					postCommands.Insert(0, "set errl = !ErrorLevel!");
+					// Any post command will eat the exit code, we need to maintain
+					postCommands.Insert(0, "set errl=!ErrorLevel!");
 					postCommands.Add("exit /b !errl!");
 				}
                 var all = preCommands


### PR DESCRIPTION
The errorlevel was only maintained after the "pause" command, but any other postcommand (like popd) will mess errorlevel.  Make this small change to maintain the error level post command properly.